### PR TITLE
Updated rtunic and unifi-controller packages

### DIFF
--- a/Casks/rtunic.rb
+++ b/Casks/rtunic.rb
@@ -1,9 +1,9 @@
 cask 'rtunic' do
-  version '1.0.15'
-  sha256 '223fb9debbef27924927b0a15056411dd942818c2c0db6c1fb7159b9f25d4f84'
+  version '1.0.16'
+  sha256 '51e1c1790789fcb35ca80c2cc5aa08826d2f24252e20a832124dafb38d85cf4e'
 
-  # d2c6jjk3vnoatm.cloudfront.net was verified as official when first introduced to the cask
-  url "https://d2c6jjk3vnoatm.cloudfront.net/spree/products/accessoies/484/0008-RTUNICv#{version}.zip"
+  # Verified manufacturer download page: http://www.realtek.com.tw/Downloads/downloadsView.aspx?Langid=1&PNid=13&PFid=56&Level=5&Conn=4&DownTypeID=3&GetDown=false
+  url "http://12244.wpc.azureedge.net/8012244/drivers/rtdrivers/cn/nic/0010-RTUNICv#{version}.zip"
   name 'rtunic'
   homepage 'https://www.anker.com/products/taxons/114/Connectivity'
 

--- a/Casks/rtunic.rb
+++ b/Casks/rtunic.rb
@@ -1,9 +1,9 @@
 cask 'rtunic' do
-  version '1.0.16'
+  version '1.0.16,484.0008'
   sha256 '51e1c1790789fcb35ca80c2cc5aa08826d2f24252e20a832124dafb38d85cf4e'
 
-  # Verified manufacturer download page: http://www.realtek.com.tw/Downloads/downloadsView.aspx?Langid=1&PNid=13&PFid=56&Level=5&Conn=4&DownTypeID=3&GetDown=false
-  url "http://12244.wpc.azureedge.net/8012244/drivers/rtdrivers/cn/nic/0010-RTUNICv#{version}.zip"
+  # d2c6jjk3vnoatm.cloudfront.net was verified as official when first introduced to the cask
+  url "https://d2c6jjk3vnoatm.cloudfront.net/spree/products/accessoies/#{version.after_comma.dots_to_slashes}-RTUNICv#{version.before_comma}.zip"
   name 'rtunic'
   homepage 'https://www.anker.com/products/taxons/114/Connectivity'
 

--- a/Casks/rtunic.rb
+++ b/Casks/rtunic.rb
@@ -1,5 +1,5 @@
 cask 'rtunic' do
-  version '1.0.16,484.0008'
+  version '1.0.16,515.0010'
   sha256 '51e1c1790789fcb35ca80c2cc5aa08826d2f24252e20a832124dafb38d85cf4e'
 
   # d2c6jjk3vnoatm.cloudfront.net was verified as official when first introduced to the cask
@@ -7,7 +7,7 @@ cask 'rtunic' do
   name 'rtunic'
   homepage 'https://www.anker.com/products/taxons/114/Connectivity'
 
-  pkg "RTUNICv#{version}/RTUNICv#{version}.pkg"
+  pkg "RTUNICv#{version.before_comma}/RTUNICv#{version.before_comma}.pkg"
 
   uninstall pkgutil: [
                        'com.realtek.usbeth109',

--- a/Casks/unifi-controller.rb
+++ b/Casks/unifi-controller.rb
@@ -1,6 +1,6 @@
 cask 'unifi-controller' do
-  version '5.4.9'
-  sha256 '5cc457db7b73f24ddc89503830368c1674fa0d3a9e740c4b497bceb4e616bbd7'
+  version '5.4.11'
+  sha256 'c9321ad3065e2a3233349a5ab06d0236600705cd13fcd3877057ef9b8c21640b'
 
   url "https://dl.ubnt.com/unifi/#{version}/UniFi.pkg"
   name 'UniFi Controller'


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [1/2] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

`rtunic v1.0.16`: Updated download location. The manufacturer is now using Azure's CDN rather than AWS Cloudfront.

`unifi-controller v5.4.11`: All checks passed.
