### PR TITLE
Migrate bose-soundtouch from main repo

### DIFF
--- a/Casks/bose-soundtouch.rb
+++ b/Casks/bose-soundtouch.rb
@@ -1,0 +1,21 @@
+cask 'bose-soundtouch' do
+  version '14.0.15-339-abb2366'
+  sha256 'f893f3e4333448f6102b8ba4ba786ca967c9422161a6750c84e77e65cc695794'
+
+  # bose.com was verified as official when first introduced to the cask
+  url "https://downloads.bose.com/ced/soundtouch/mr4_2016/SoundTouch-#{version}-osx-10.9-installer.app.dmg"
+  name 'Bose Soundtouch Controller App'
+  homepage 'https://www.soundtouch.com/'
+
+  depends_on macos: '>= :mavericks'
+
+  installer script: 'SoundTouch-osx-installer.app/Contents/MacOS/installbuilder.sh',
+            args:   %w[--mode unattended],
+            sudo:   true
+
+  uninstall script: {
+                      executable: '/Applications/SoundTouch/uninstall.app/Contents/MacOS/installbuilder.sh',
+                      args:       %w[--mode unattended],
+                      sudo:       true,
+                    }
+end


### PR DESCRIPTION
After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.
