### PR TITLE
Update silicon-labs-vcp-driver

### DIFF
--- a/Casks/silicon-labs-vcp-driver.rb
+++ b/Casks/silicon-labs-vcp-driver.rb
@@ -1,11 +1,13 @@
 cask 'silicon-labs-vcp-driver' do
-  version :latest
-  sha256 :no_check
+  version '4.10.15'
+  sha256 'b5532118d3ea97080ff57d04e4941295e2542df7d6180cebe3d5684aed13072b'
 
-  url 'https://www.silabs.com/Support%20Documents/Software/Mac_OSX_VCP_Driver.zip'
+  url 'https://www.silabs.com/documents/public/software/Mac_OSX_VCP_Driver.zip'
+  appcast 'https://www.silabs.com/documents/public/software/Mac_OSX_VCP_Driver_Release_Notes.txt',
+          checkpoint: '080631469bed4a8749d2ac007a2571102b2494cefa4a4530013edbb08d4be940'
   name 'Silicon Labs VCP Driver'
   name 'CP210x USB to UART Bridge VCP Driver'
-  homepage 'https://www.silabs.com/products/mcu/pages/usbtouartbridgevcpdrivers.aspx'
+  homepage 'https://www.silabs.com/products/development-tools/software/usb-to-uart-bridge-vcp-drivers'
 
   container nested: 'SiLabsUSBDriverDisk.dmg'
 


### PR DESCRIPTION
* Update download and homepage URLs
* Add version (4.10.15), checksum and appcast checkpoint

After making all changes to the cask:

- [x] `brew cask audit --download silicon-labs-vcp-driver` is error-free.
- [x] `brew cask style --fix silicon-labs-vcp-driver` reports no offenses.
- [x] The commit message includes the cask’s name and version.
