### PR TITLE
Reintroduce recently deleted canon-imagerunner-printer-driver-ufrii cask

### DIFF
--- a/Casks/canon-imagerunner-printer-driver-ufrii.rb
+++ b/Casks/canon-imagerunner-printer-driver-ufrii.rb
@@ -3,6 +3,8 @@ cask 'canon-imagerunner-printer-driver-ufrii' do
   sha256 'f00b5dff45b0e6642fb17714a180d78eb93b352b21a5fef4b96d3f798a286126'
 
   url "https://downloads.canon.com/bisg2016/drivers/mac/UFRII_#{version}_Mac.zip"
+  appcast 'https://www.usa.canon.com/internet/PA_NWSupport/driversDownloads?model=15802&os=MACOS_V10_12&type=DS&lang=English',
+           checkpoint: '3c848ecfe8545ac2c98964b5db3d5078d649b713a7ad8f717ec84f3bb55bcce2'
   name 'Canon imageRUNNER UFRII Printer Driver'
   homepage 'https://www.usa.canon.com/internet/portal/us/home/support/details/copiers-mfps-fax-machines/support-multifunction/imagerunner-2018'
 

--- a/Casks/canon-imagerunner-printer-driver-ufrii.rb
+++ b/Casks/canon-imagerunner-printer-driver-ufrii.rb
@@ -4,7 +4,7 @@ cask 'canon-imagerunner-printer-driver-ufrii' do
 
   url "https://downloads.canon.com/bisg2016/drivers/mac/UFRII_#{version}_Mac.zip"
   appcast 'https://www.usa.canon.com/internet/PA_NWSupport/driversDownloads?model=15802&os=MACOS_V10_12&type=DS&lang=English',
-           checkpoint: '3c848ecfe8545ac2c98964b5db3d5078d649b713a7ad8f717ec84f3bb55bcce2'
+          checkpoint: '3c848ecfe8545ac2c98964b5db3d5078d649b713a7ad8f717ec84f3bb55bcce2'
   name 'Canon imageRUNNER UFRII Printer Driver'
   homepage 'https://www.usa.canon.com/internet/portal/us/home/support/details/copiers-mfps-fax-machines/support-multifunction/imagerunner-2018'
 

--- a/Casks/canon-imagerunner-printer-driver-ufrii.rb
+++ b/Casks/canon-imagerunner-printer-driver-ufrii.rb
@@ -1,0 +1,12 @@
+cask 'canon-imagerunner-printer-driver-ufrii' do
+  version '10.11.00'
+  sha256 'f00b5dff45b0e6642fb17714a180d78eb93b352b21a5fef4b96d3f798a286126'
+
+  url "https://downloads.canon.com/bisg2016/drivers/mac/UFRII_#{version}_Mac.zip"
+  name 'Canon imageRUNNER UFRII Printer Driver'
+  homepage 'https://www.usa.canon.com/internet/portal/us/home/support/details/copiers-mfps-fax-machines/support-multifunction/imagerunner-2018'
+
+  pkg 'Office/UFRII_LT_LIPS_LX_Installer.pkg'
+
+  uninstall pkgutil: 'jp.co.canon.CUPSPrinter.*'
+end


### PR DESCRIPTION
This PR reintroduces `canon-imagerunner-printer-driver-ufrii` Cask recently deleted in #9 because of #8. The uninstall issue is now fixed by Homebrew/brew#2059. `appcast` removed to fix `brew cask audit` (it was not a proper AppCast XML anyway).

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not already refused in [closed issues].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-drivers/pulls
[closed issues]: https://github.com/caskroom/homebrew-drivers/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
