### PR TITLE
canon-pixma-mg6200-printer-driver cask

### DIFF
--- a/Casks/canon-pixma-mg6200-printer-driver.rb
+++ b/Casks/canon-pixma-mg6200-printer-driver.rb
@@ -1,0 +1,14 @@
+cask 'canon-pixma-mg6200-printer-driver' do
+  version '16.10.0.0'
+  sha256 'af0258d083e5dccb90d215925710688001e210181fca36833095c1d182b340e0'
+
+  # gdlp01.c-wss.com was verified as official when first introduced to the cask
+  url "http://gdlp01.c-wss.com/gds/5/0100005655/03/mcpd-mac-mg6200-#{version.dots_to_underscores}-ea21_3.dmg"
+  name 'Canon PIXMA MG6200 series CUPS Printer Driver'
+  homepage 'https://www.usa.canon.com/internet/portal/us/home/support/details/printers/support-inkjet-printer/mg-series/pixma-mg6220'
+
+  pkg "PrinterDriver_MG6200 series_#{version.no_dots}.pkg"
+
+  uninstall pkgutil: "jp.co.canon.pkg.MG6200-#{version.no_dots}",
+            delete:  '/Library/Printers/PPDs/Contents/Resources/CanonIJMG6200series.ppd.gz'
+end


### PR DESCRIPTION
This cask adds drivers for Canon PIXMA printers of MG6200 series (MG6220, MG6240, MG6250).

Unfortunately, Canon drivers for some of the printer lines (including PIXMA) are quite specific - separate driver for each series, which is usually very few printers, so this cask is likely not to be used a lot. It can be, on the other hand, used as a template for similar drivers in the same line. I would imagine this is a problem for many drivers, so please let me know what is the official policy for such casks - I'm happy to move it to a personal tap if it's not useful enough.

---
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-drivers/pulls
[closed issues]: https://github.com/caskroom/homebrew-drivers/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
