### PR TITLE
Update bose-soundtouch to 14.80.6-708-9bd051b

### DIFF
--- a/Casks/bose-soundtouch.rb
+++ b/Casks/bose-soundtouch.rb
@@ -17,5 +17,13 @@ cask 'bose-soundtouch' do
                       executable: '/Applications/SoundTouch/uninstall.app/Contents/MacOS/installbuilder.sh',
                       args:       %w[--mode unattended],
                       sudo:       true,
-                    }
+                    },
+            quit:   'com.Bose.SoundTouch'
+
+  zap delete: [
+                '~/Library/Application Support/SoundTouch',
+                '~/Library/Caches/SoundTouch',
+                '~/Library/Saved Application State/com.Bose.SoundTouch application.savedState',
+                '~/Library/Saved Application State/com.Bose.SoundTouch.savedState',
+              ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.