### PR TITLE
Update displaylink to 3.0,740

### DIFF
--- a/Casks/displaylink.rb
+++ b/Casks/displaylink.rb
@@ -3,8 +3,8 @@ cask 'displaylink' do
     version '2.2,121'
     sha256 '5c9a97a476b5ff27811491eebb653a03c96f899562b67566c24100d8593b1daa'
   else
-    version '2.6,707'
-    sha256 '5b1c7c5ba941a62a230316df13cdbe9be7559754e808d3480a6197c1a11a779a'
+    version '3.0,740'
+    sha256 '61f5b4060ced82a97877eceded8c400f1ecca6648fb4590dd201bfb6b3741051'
   end
 
   url "http://www.displaylink.com/downloads/file?id=#{version.after_comma}",


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.