### PR TITLE
Update xerox-print-driver to 3.121.0_1854

### DIFF
--- a/Casks/xerox-print-driver.rb
+++ b/Casks/xerox-print-driver.rb
@@ -15,9 +15,9 @@ cask 'xerox-print-driver' do
     sha256 'ed958701b6adca202f0b7936cfea0fac64c2161e228f35e00f341e29df36c18f'
     url "http://download.support.xerox.com/pub/drivers/CQ8570/drivers/macosx107/pt_BR/XeroxPrintDriver.#{version}.dmg"
   else
-    version '3.113.0_1840'
-    sha256 '76efdefd088639c6c8de6730b1059f216882d4124fdb66fe5ab30847f2840d0f'
-    url "http://download.support.xerox.com/pub/drivers/CQ8570/drivers/macosx1010/ar/XeroxPrintDriver_#{version}.dmg"
+    version '3.121.0_1854'
+    sha256 '12584af50c9dcf7a529eea3b1ee4346d3f76ba18a9c5b7b86c28544f33abaad5'
+    url "http://download.support.xerox.com/pub/drivers/VERSANT_180/drivers/macosx1010/ar/XeroxPrintDriver_#{version}.dmg"
   end
 
   pkg "Xerox Print Driver #{version.major_minor_patch}.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.