### PR TITLE
Add version and sha to brotherprinterdrivers

### DIFF
--- a/Casks/brotherprinterdrivers.rb
+++ b/Casks/brotherprinterdrivers.rb
@@ -1,6 +1,6 @@
 cask 'brotherprinterdrivers' do
-  version :latest
-  sha256 :no_check
+  version '4.1'
+  sha256 'b6cf4890115bc488436abab7d4348987b8f37aaef915f38060b459db28a74e88'
 
   url 'http://support.apple.com/downloads/DL1881/en_US/brotherprinterdrivers.dmg'
   name 'Brother Printer Drivers'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

I misunderstood the `version` stanza when I added this in #19 so I've updated the cask with `version` and `sha`.