### PR TITLE
Update canon-imagerunner-printer-driver-ufrii to 10.12.00

### DIFF
--- a/Casks/canon-imagerunner-printer-driver-ufrii.rb
+++ b/Casks/canon-imagerunner-printer-driver-ufrii.rb
@@ -1,10 +1,10 @@
 cask 'canon-imagerunner-printer-driver-ufrii' do
-  version '10.11.00'
-  sha256 'f00b5dff45b0e6642fb17714a180d78eb93b352b21a5fef4b96d3f798a286126'
+  version '10.12.00'
+  sha256 '55aca054f2612421fea2f1e56d46a6da0cc4fb282b40c9b07fb2ad109da8062a'
 
-  url "https://downloads.canon.com/bisg2016/drivers/mac/UFRII_#{version}_Mac.zip"
+  url "https://downloads.canon.com/bisg2017/drivers/mac/UFRII_v#{version}_Mac.zip"
   appcast 'https://www.usa.canon.com/internet/PA_NWSupport/driversDownloads?model=15802&os=MACOS_V10_12&type=DS&lang=English',
-          checkpoint: '3c848ecfe8545ac2c98964b5db3d5078d649b713a7ad8f717ec84f3bb55bcce2'
+          checkpoint: '8070640fd55e4474476109c7de55d0b63716d5c540d477bdea904a1c00548b2b'
   name 'Canon imageRUNNER UFRII Printer Driver'
   homepage 'https://www.usa.canon.com/internet/portal/us/home/support/details/copiers-mfps-fax-machines/support-multifunction/imagerunner-2018'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.