### PR TITLE
Update wacom-graphire2-tablet to 6.1.7-4

### DIFF
--- a/Casks/wacom-graphire2-tablet.rb
+++ b/Casks/wacom-graphire2-tablet.rb
@@ -3,7 +3,7 @@ cask 'wacom-graphire2-tablet' do
   sha256 '593cdd4c51bee7714aecbef77d6e3809dd80a8393893ee1937f9c15c567bb4b4'
 
   # wacom.asia/sites/default/files/drivers was verified as official when first introduced to the cask
-  url "https://www.wacom.asia/sites/default/files/drivers/WacomTablet_#{version}.dmg"
+  url "http://www.wacom.asia/sites/default/files/drivers/WacomTablet_#{version}.dmg"
   name 'Graphire2 Wacom Tablet'
   homepage 'https://www.wacom.com/support/graphire-support'
 


### PR DESCRIPTION
- Download link is no available in SSL anymore

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.