### PR TITLE
wacom-graphire2-tablet remove `uninstall delete: .app`

### DIFF
--- a/Casks/wacom-graphire2-tablet.rb
+++ b/Casks/wacom-graphire2-tablet.rb
@@ -21,8 +21,7 @@ cask 'wacom-graphire2-tablet' do
                          'com.silabs.driver.CP210xVCPDriver',
                          'com.silabs.driver.CP210xVCPDriver64',
                        ],
-            pkgutil:   'com.wacom.TabletInstaller',
-            delete:    '/Applications/Wacom Tablet.localized'
+            pkgutil:   'com.wacom.installwacomtablet'
 
   zap delete: [
                 '~/Library//Preferences/com.wacom.wacomtablet.prefs',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

https://github.com/caskroom/homebrew-cask/issues/30801

Updated `uninstall`.