### PR TITLE
Update and rename tomtom-mysports-connect.rb to tomtom-sports-connect.rb

### DIFF
--- a/Casks/tomtom-sports-connect.rb
+++ b/Casks/tomtom-sports-connect.rb
@@ -1,18 +1,17 @@
-cask 'tomtom-mysports-connect' do
+cask 'tomtom-sports-connect' do
   version :latest
   sha256 :no_check
 
   # sports.tomtom-static.com was verified as official when first introduced to the cask
-  url 'https://sports.tomtom-static.com/downloads/desktop/mysportsconnect/latest/TomTomMySportsConnectInstaller.pkg'
+  url 'https://sports.tomtom-static.com/downloads/desktop/mysportsconnect/latest/TomTomSportsConnectInstaller.pkg'
   name 'TomTom MySports Connect'
   homepage 'https://www.tomtom.com/mysports/getstarted'
 
-  pkg 'TomTomMySportsConnectInstaller.pkg'
+  pkg 'TomTomSportsConnectInstaller.pkg'
 
   uninstall quit:    'com.tomtom.mysportsconnect',
             pkgutil: [
                        'com.tomtom.tomtomfa.pkg',
                        'com.tomtom.tomtomfa.temp.pkg',
-                     ],
-            delete:  '/Applications/TomTom MySports Connect.app'
+                     ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Renamed cask to match software name.

Updated `url` and `pkg`. 

`uninstall quit: com.tomtom.mysportsconnect` is still correct.

Removed `delete: .app`.

https://github.com/caskroom/homebrew-cask/issues/30801