### PR TITLE
Update xerox-print-driver to 3.122.1_1858

### DIFF
--- a/Casks/xerox-print-driver.rb
+++ b/Casks/xerox-print-driver.rb
@@ -15,8 +15,8 @@ cask 'xerox-print-driver' do
     sha256 'ed958701b6adca202f0b7936cfea0fac64c2161e228f35e00f341e29df36c18f'
     url "http://download.support.xerox.com/pub/drivers/CQ8570/drivers/macosx107/pt_BR/XeroxPrintDriver.#{version}.dmg"
   else
-    version '3.121.0_1854'
-    sha256 '12584af50c9dcf7a529eea3b1ee4346d3f76ba18a9c5b7b86c28544f33abaad5'
+    version '3.122.1_1858'
+    sha256 'c86378937a6cf3f473758d180c727a9d265e739c05d3b582f07298ff537be7c6'
     url "http://download.support.xerox.com/pub/drivers/VERSANT_180/drivers/macosx1010/ar/XeroxPrintDriver_#{version}.dmg"
   end
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
