### PR TITLE
Update synology-cloud-station-drive to 4.2.3-4385

### DIFF
--- a/Casks/synology-cloud-station-drive.rb
+++ b/Casks/synology-cloud-station-drive.rb
@@ -1,12 +1,12 @@
 cask 'synology-cloud-station-drive' do
-  version '4.2.2-4379'
-  sha256 '63c108164de7440cc7b3680e79a462c26a94f591f78380290a83782a30098f43'
+  version '4.2.3-4385'
+  sha256 '0bf76452615a1bef2e8c3efdc9fe58b552842793c742b2e21f94ed89220a0c03'
 
   url "https://global.download.synology.com/download/Tools/CloudStationDrive/#{version}/Mac/Installer/synology-cloud-station-drive-#{version.sub(%r{.*-}, '')}.dmg"
   name 'Synology Cloud Station Drive'
   homepage 'https://www.synology.com/'
 
-  pkg 'Install Cloud Station Drive.pkg'
+  pkg 'Install Cloud Station Drive.pkg', allow_untrusted: true
 
   uninstall pkgutil:   'com.synology.CloudStation',
             launchctl: 'com.synology.Synology Cloud Station'


### PR DESCRIPTION
Added `allow_untrusted: true` to avoid certificate error

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.