### PR TITLE
xerox-print-driver - remove `leopard` version

### DIFF
--- a/Casks/xerox-print-driver.rb
+++ b/Casks/xerox-print-driver.rb
@@ -2,11 +2,7 @@ cask 'xerox-print-driver' do
   name 'Xerox Print Driver'
   homepage 'http://www.support.xerox.com/support/colorqube-8900/downloads/enus.html'
 
-  if MacOS.version <= :leopard
-    version '2.94.3'
-    sha256 '1c59094ad2f39e2a086dfb59adc555fc87d1f88a8ac6ff034e7580eed55cf360'
-    url "http://download.support.xerox.com/pub/drivers/CQ8570/drivers/macosx/pt_BR/10.5.XeroxPrintDriver.#{version}.dmg"
-  elsif MacOS.version <= :snow_leopard
+  if MacOS.version <= :snow_leopard
     version '2.112.0'
     sha256 '3517cb64f283f12c60030710073812131361ddae358950bc35afe72b163a9bf7'
     url "http://download.support.xerox.com/pub/drivers/CQ8570/drivers/macosx/pt_BR/XeroxPrintDriver.#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.