### PR TITLE
Remove allow_untrusted for synology-cloud-station-drive 4.2.3-4385

### DIFF
--- a/Casks/synology-cloud-station-drive.rb
+++ b/Casks/synology-cloud-station-drive.rb
@@ -6,7 +6,7 @@ cask 'synology-cloud-station-drive' do
   name 'Synology Cloud Station Drive'
   homepage 'https://www.synology.com/'
 
-  pkg 'Install Cloud Station Drive.pkg', allow_untrusted: true
+  pkg 'Install Cloud Station Drive.pkg'
 
   uninstall pkgutil:   'com.synology.CloudStation',
             launchctl: 'com.synology.Synology Cloud Station'


### PR DESCRIPTION
It is not required for me. I think it has been added by mistake.

Signed-off-by: Jean-Pierre Matsumoto <jpmat296@gmail.com>

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.