### PR TITLE
Update focusrite-control to 2.1.5,31868

### DIFF
--- a/Casks/focusrite-control.rb
+++ b/Casks/focusrite-control.rb
@@ -1,9 +1,9 @@
 cask 'focusrite-control' do
-  version '2.1.5'
+  version '2.1.5,31868'
   sha256 '9faf8a1e2f51e9638c155238cb1ec85a74028cd065813d8717a53d7d72350b7e'
 
-  # d3se566zfvnmhf.cloudfront.net was verified as official when first introduced to the cask
-  url "https://d3se566zfvnmhf.cloudfront.net/sites/default/files/focusrite/downloads/31868/focusrite-control-#{version}.dmg"
+  # d2zjg0qo565n2.cloudfront.net was verified as official when first introduced to the cask
+  url "https://d2zjg0qo565n2.cloudfront.net/sites/default/files/focusrite/downloads/#{version.after_comma}/focusrite-control-#{version.before_comma}.dmg"
   name 'Focusrite Control'
   homepage 'https://us.focusrite.com/downloads?product=Scarlett+18i8'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.