### PR TITLE
Update yubico-authenticator to 4.1.1

### DIFF
--- a/Casks/yubico-authenticator.rb
+++ b/Casks/yubico-authenticator.rb
@@ -1,10 +1,10 @@
 cask 'yubico-authenticator' do
-  version '4.1.0'
-  sha256 'c216a45f631899fc2869fd0f1d5b851a2df3db009a1e50bf93b219a611ff83b6'
+  version '4.1.1'
+  sha256 'c16eb87040499da4b3c8dacbd1d710fc057e90185f5181296b06a099a38c42ae'
 
   url "https://developers.yubico.com/yubioath-desktop/Releases/yubioath-desktop-#{version}-mac.pkg"
   appcast 'https://developers.yubico.com/yubioath-desktop/Release_Notes.html',
-          checkpoint: 'b95445abc24b000154851bd7e3d3fefa84507e5455b140b3bb899d2954a1dcd4'
+          checkpoint: '9adba51e62f0d1581a4ddeafc6cfc75e15cea0a6a566f0d2d74d329b8c298735'
   name 'Yubico Authenticator'
   homepage 'https://developers.yubico.com/yubioath-desktop/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.