### PR TITLE
Update yubico-authenticator to 4.1.2

### DIFF
--- a/Casks/yubico-authenticator.rb
+++ b/Casks/yubico-authenticator.rb
@@ -1,10 +1,10 @@
 cask 'yubico-authenticator' do
-  version '4.1.1'
-  sha256 'c16eb87040499da4b3c8dacbd1d710fc057e90185f5181296b06a099a38c42ae'
+  version '4.1.2'
+  sha256 'd9f104a5631b6628b16eb996eaa3b33cdd9560ffc15b0098234b00d281b666c6'
 
   url "https://developers.yubico.com/yubioath-desktop/Releases/yubioath-desktop-#{version}-mac.pkg"
   appcast 'https://developers.yubico.com/yubioath-desktop/Release_Notes.html',
-          checkpoint: '9adba51e62f0d1581a4ddeafc6cfc75e15cea0a6a566f0d2d74d329b8c298735'
+          checkpoint: '089bbd0911df46721f3ddcd8a955729e45583bac92c35a3ab1e55837b4812952'
   name 'Yubico Authenticator'
   homepage 'https://developers.yubico.com/yubioath-desktop/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.