### PR TITLE
Update bragi-updater to 1.1.1

### DIFF
--- a/Casks/bragi-updater.rb
+++ b/Casks/bragi-updater.rb
@@ -1,10 +1,10 @@
 cask 'bragi-updater' do
-  version '1.1.0'
-  sha256 '305fd036fae31b765455c8dab9176f12b8f98a526d45ead0bb9edc41a2940c86'
+  version '1.1.1'
+  sha256 '999f0698385e34bd85460cdbad8bbeaabde27ec91c5f53961d55547a5801060b'
 
   url "http://update.bragi.com/bin/Bragi%20Updater-#{version}.dmg"
   appcast 'http://update.bragi.com/',
-          checkpoint: 'bd743631d7dd53de5b729500723b1b0ce47412b4ee8113dbb29a612362c1d49d'
+          checkpoint: '21eaf7775f39fcfe8ea03a60fd9032805829cb15b13a3bb9de96ae44da156e73'
   name 'Bragi Updater'
   homepage 'http://update.bragi.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.