### PR TITLE
Update bose-soundtouch to 14.80.6-708-9bd051b

### DIFF
--- a/Casks/bose-soundtouch.rb
+++ b/Casks/bose-soundtouch.rb
@@ -4,6 +4,8 @@ cask 'bose-soundtouch' do
 
   # bose.com was verified as official when first introduced to the cask
   url "https://downloads.bose.com/ced/soundtouch/mr4_2016/SoundTouch-app-installer-#{version}.dmg"
+  appcast 'https://downloads.bose.com/ced/soundtouch/soundtouch_controller_app/index.html',
+          checkpoint: '93458a17a19ac42e6f8cf9e925257a69618800daff8dfa9d698f6f6e7c6cae8e'
   name 'Bose Soundtouch Controller App'
   homepage 'https://www.soundtouch.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.