### PR TITLE
Update eyetv to 3.6.9_7517

### DIFF
--- a/Casks/eyetv.rb
+++ b/Casks/eyetv.rb
@@ -1,11 +1,11 @@
 cask 'eyetv' do
-  version '3.6.9_7416'
-  sha256 '96d287b9f1fb5b3341105dd9f9e4cafbed2daf148133ee6b2d1c0cdd0c2ff258'
+  version '3.6.9_7517'
+  sha256 'a4a835c8a38c12ec3f43f29ab36e520f418894b15aeae3f1e3c47267306abe27'
 
   # d2ax8v8radog32.cloudfront.net was verified as official when first introduced to the cask
-  url "https://d2ax8v8radog32.cloudfront.net/eyetv3/Geniatech_eyetv_#{version}.dmg"
+  url "https://www.geniatech.eu/eyetv/wp-content/uploads/2017/04/EyeTV#{version}.dmg_.zip"
   appcast 'https://www.geniatech.eu/eyetv/support/eyetv-3-en/',
-          checkpoint: '61117cf7e47fb1d7c1be173fb9c573a17f6ec66289236f026a0db8fa14ef22c6'
+          checkpoint: 'd09585cd10c20c3072ec70a1cb6a98be471eea7821c6c61722d8d3213cfe4780'
   name 'EyeTV'
   homepage 'https://www.geniatech.eu/eyetv/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.