### PR TITLE
Update logitech-options to 6.60.446

### DIFF
--- a/Casks/logitech-options.rb
+++ b/Casks/logitech-options.rb
@@ -1,11 +1,12 @@
 cask 'logitech-options' do
-  version '6.40.106'
-  sha256 '256ae2b791d3b09ee68d463d5799b7b651a8bcc12339174475d54b84765705d7'
+  version '6.60.446'
+  sha256 '486861842ebf9fd307c23780be692689c4cf24397fa9fa58485ea558b358895e'
 
   url "https://www.logitech.com/pub/techsupport/options/Options_#{version}.zip"
   name 'Logitech Options'
   homepage 'https://support.logitech.com/en_us/software/options'
 
+  auto_updates true
   depends_on macos: '>= :mavericks'
 
   pkg "LogiMgr Installer #{version}.app/Contents/Resources/LogiMgr.mpkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.