### PR TITLE
Update wacom-graphire2-tablet to 6.2.0w4

### DIFF
--- a/Casks/wacom-graphire2-tablet.rb
+++ b/Casks/wacom-graphire2-tablet.rb
@@ -1,6 +1,6 @@
 cask 'wacom-graphire2-tablet' do
-  version '6.1.7-4'
-  sha256 '593cdd4c51bee7714aecbef77d6e3809dd80a8393893ee1937f9c15c567bb4b4'
+  version '6.2.0w4'
+  sha256 'b9e7c758f56595b73eb77eeaca7599da1852d914b50a8bf7ba58b897e21dbe07'
 
   # wacom.asia/sites/default/files/drivers was verified as official when first introduced to the cask
   url "http://www.wacom.asia/sites/default/files/drivers/WacomTablet_#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.