### PR TITLE
Update eyetv to 3.6.9_7518

### DIFF
--- a/Casks/eyetv.rb
+++ b/Casks/eyetv.rb
@@ -4,7 +4,7 @@ cask 'eyetv' do
 
   # file.geniatech.com/eyetv3 was verified as official when first introduced to the cask
   url "http://file.geniatech.com/eyetv3/EyeTV#{version}.dmg"
-  appcast 'https://www.geniatech.eu/eyetv/support/eyetv-3-en/',
+  appcast "https://www.geniatech.eu/eyetv/support/eyetv-#{version.major}-en/",
           checkpoint: '3e6674a84a0329cf38da68c4de888af358441c11235913ae0dfa968b98de763e'
   name 'EyeTV'
   homepage 'https://www.geniatech.eu/eyetv/'

--- a/Casks/eyetv.rb
+++ b/Casks/eyetv.rb
@@ -1,11 +1,11 @@
 cask 'eyetv' do
-  version '3.6.9_7517'
-  sha256 'a4a835c8a38c12ec3f43f29ab36e520f418894b15aeae3f1e3c47267306abe27'
+  version '3.6.9_7518'
+  sha256 'f6108cd5c2d6626c40b21e01b585d8a4f4a681cffd39b236376fce618133e974'
 
-  # d2ax8v8radog32.cloudfront.net was verified as official when first introduced to the cask
-  url "https://www.geniatech.eu/eyetv/wp-content/uploads/2017/04/EyeTV#{version}.dmg_.zip"
+  # file.geniatech.com/eyetv3 was verified as official when first introduced to the cask
+  url "http://file.geniatech.com/eyetv3/EyeTV#{version}.dmg"
   appcast 'https://www.geniatech.eu/eyetv/support/eyetv-3-en/',
-          checkpoint: 'd09585cd10c20c3072ec70a1cb6a98be471eea7821c6c61722d8d3213cfe4780'
+          checkpoint: '3e6674a84a0329cf38da68c4de888af358441c11235913ae0dfa968b98de763e'
   name 'EyeTV'
   homepage 'https://www.geniatech.eu/eyetv/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}