### PR TITLE
Update garmin-virb-edit to 5.1.0

### DIFF
--- a/Casks/garmin-virb-edit.rb
+++ b/Casks/garmin-virb-edit.rb
@@ -1,6 +1,6 @@
 cask 'garmin-virb-edit' do
-  version '4.2.3'
-  sha256 'dcc9bf63494949f1eba13bbbb10d29a3de126865c70d1c26f25bd563013b75d9'
+  version '5.1.0'
+  sha256 'ba573a2841c9fc34e9c88995bef54de7b42e9ff0c94bdd7d0b40615005b531f9'
 
   url "http://download.garmin.com/software/VIRBEditforMac_#{version.no_dots}.dmg"
   name 'Garmin VIRB Edit'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}