### PR TITLE
Update wd-my-cloud - pkg allow untrusted

### DIFF
--- a/Casks/wd-my-cloud.rb
+++ b/Casks/wd-my-cloud.rb
@@ -6,7 +6,7 @@ cask 'wd-my-cloud' do
   name 'WD My Cloud'
   homepage 'https://www.wdc.com/'
 
-  pkg 'Install WD My Cloud.pkg'
+  pkg 'Install WD My Cloud.pkg', allow_untrusted: true
 
   uninstall  pkgutil: 'com.wdc.wdMyCloud.*',
              delete:  '~/Desktop/WD My Cloud.app'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

https://github.com/caskroom/homebrew-cask/issues/35981

`pkg` requires `allow_untrusted`