### PR TITLE
Migrate moveslink2

### DIFF
--- a/Casks/moveslink2.rb
+++ b/Casks/moveslink2.rb
@@ -1,0 +1,19 @@
+cask 'moveslink2' do
+  # note: "2" is not a version number, but an intrinsic part of the product name
+  version '1.4.4'
+  sha256 '474ec979b4fb9b6c2319a61162e95ca895eb9949b3f2a72a7365561bcf651a8c'
+
+  # d1c229iib3zm7m.cloudfront.net was verified as official when first introduced to the cask
+  url "https://d1c229iib3zm7m.cloudfront.net/mac/Moveslink2_#{version.dots_to_underscores}.dmg"
+  appcast 'https://d1c229iib3zm7m.cloudfront.net/mac/appcast.xml',
+          checkpoint: 'c1d5f1b9a7c848fde84a61e12ed6232eb517126ad92be680ba4e37c76f902e14'
+  name 'Suunto Moveslink2'
+  homepage 'http://www.movescount.com/connect?os=mac'
+
+  auto_updates true
+
+  app 'Moveslink2.app'
+
+  uninstall login_item: 'Moveslink2',
+            quit:       'Suunto.Moveslink2'
+end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Renamed according to the token reference.

Updated uninstall

https://github.com/caskroom/homebrew-cask/pull/36272