### PR TITLE
Update brotherprinterdrivers to 4.1.1

### DIFF
--- a/Casks/brotherprinterdrivers.rb
+++ b/Casks/brotherprinterdrivers.rb
@@ -1,10 +1,10 @@
 cask 'brotherprinterdrivers' do
-  version :latest
-  sha256 :no_check
+  version '4.1.1'
+  sha256 '4f12496a351ecf2da717239c4c85a311401ddd465a036f4c175cfcc74abf58f6'
 
-  url 'http://support.apple.com/downloads/DL1881/en_US/brotherprinterdrivers.dmg'
+  url "http://support.apple.com/downloads/DL1927/en_US/brotherprinterdrivers#{version}.dmg"
   name 'Brother Printer Drivers'
-  homepage 'https://support.apple.com/kb/DL1881'
+  homepage 'https://support.apple.com/kb/DL1927'
 
   pkg 'BrotherPrinterDrivers.pkg'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.