### PR TITLE
Update LG OnScreen Control to v2.46

### DIFF
--- a/Casks/lg-onscreencontrol.rb
+++ b/Casks/lg-onscreencontrol.rb
@@ -1,9 +1,8 @@
 cask 'lg-onscreencontrol' do
   version '2.46'
   sha256 '943cfd2d59d56b47ae244d175eaa4344cb49e5e39a4efd812ba78939970e69e8'
-  
-  # http://www.lg.com/us/support-product/lg-27UD69P-W#manuals retrieved 2017-07-08
-  url "http://www.lg.com/us/lgecs.downloadFile.ldwf?DOC_ID=20150320442554&what=MANUAL&fromSystem=LG.COM&fileId=q0YuHZx6oufr6zJ6znVLmg&ORIGINAL_NAME_b1_a1=MAC_OSC.#{version.major_minor_patch}.zip"
+
+  url "http://www.lg.com/us/lgecs.downloadFile.ldwf?DOC_ID=20150320442554&what=MANUAL&fromSystem=LG.COM&fileId=q0YuHZx6oufr6zJ6znVLmg&ORIGINAL_NAME_b1_a1=MAC_OSC.#{version}.zip"
   name 'LG OnScreen Control'
   homepage 'http://www.lg.com/'
 

--- a/Casks/lg-onscreencontrol.rb
+++ b/Casks/lg-onscreencontrol.rb
@@ -1,6 +1,6 @@
 cask 'lg-onscreencontrol' do
   version '2.46'
-  sha256 '7263b8cb714cf25db16cee7310ba03a79cc28754cb18f55c30642cc745d64740'
+  sha256 '943cfd2d59d56b47ae244d175eaa4344cb49e5e39a4efd812ba78939970e69e8'
   
   lgosc_doc_id = '20150320442554'
   lgosc_file_id = 'q0YuHZx6oufr6zJ6znVLmg'

--- a/Casks/lg-onscreencontrol.rb
+++ b/Casks/lg-onscreencontrol.rb
@@ -1,12 +1,9 @@
 cask 'lg-onscreencontrol' do
-  version '2.46'
+  version '2.46,'
   sha256 '943cfd2d59d56b47ae244d175eaa4344cb49e5e39a4efd812ba78939970e69e8'
   
-  lgosc_doc_id = '20150320442554'
-  lgosc_file_id = 'q0YuHZx6oufr6zJ6znVLmg'
-  lgosc_original_name = "MAC_OSC.#{version}.zip"
-
-  url "http://www.lg.com/us/lgecs.downloadFile.ldwf?DOC_ID=#{lgosc_doc_id}&what=MANUAL&fromSystem=LG.COM&fileId=#{lgosc_file_id}&ORIGINAL_NAME_b1_a1=#{lgosc_original_name}"
+  # http://www.lg.com/us/support-product/lg-27UD69P-W#manuals retrieved 2017-07-08
+  url "http://www.lg.com/us/lgecs.downloadFile.ldwf?DOC_ID=20150320442554&what=MANUAL&fromSystem=LG.COM&fileId=q0YuHZx6oufr6zJ6znVLmg&ORIGINAL_NAME_b1_a1=MAC_OSC.#{version.major_minor_patch}.zip"
   name 'LG OnScreen Control'
   homepage 'http://www.lg.com/'
 

--- a/Casks/lg-onscreencontrol.rb
+++ b/Casks/lg-onscreencontrol.rb
@@ -1,5 +1,5 @@
 cask 'lg-onscreencontrol' do
-  version '2.46,'
+  version '2.46'
   sha256 '943cfd2d59d56b47ae244d175eaa4344cb49e5e39a4efd812ba78939970e69e8'
   
   # http://www.lg.com/us/support-product/lg-27UD69P-W#manuals retrieved 2017-07-08

--- a/Casks/lg-onscreencontrol.rb
+++ b/Casks/lg-onscreencontrol.rb
@@ -1,12 +1,16 @@
 cask 'lg-onscreencontrol' do
-  version '1.37'
+  version '2.46'
   sha256 '7263b8cb714cf25db16cee7310ba03a79cc28754cb18f55c30642cc745d64740'
+  
+  lgosc_doc_id = '20150320442554'
+  lgosc_file_id = 'q0YuHZx6oufr6zJ6znVLmg'
+  lgosc_original_name = "MAC_OSC.#{version}.zip"
 
-  url "http://www.lg.com/us/lgecs.downloadFile.ldwf?DOC_ID=20150116943155&what=MANUAL&fromSystem=LG.COM&fileId=kF2MFoPcI9YSuCcD23D9w&ORIGINAL_NAME_b1_a1=MAC_OnScreenControl.#{version}.zip"
+  url "http://www.lg.com/us/lgecs.downloadFile.ldwf?DOC_ID=#{lgosc_doc_id}&what=MANUAL&fromSystem=LG.COM&fileId=#{lgosc_file_id}&ORIGINAL_NAME_b1_a1=#{lgosc_original_name}"
   name 'LG OnScreen Control'
   homepage 'http://www.lg.com/'
 
-  pkg "OnScreenControl.#{version}.pkg"
+  pkg "OnScreenControl_V#{version}.pkg"
 
   uninstall quit:    'com.LGSI.-.OnScreen-Control',
             pkgutil: 'com.lge.onscreenControl.*'

--- a/Casks/lg-onscreencontrol.rb
+++ b/Casks/lg-onscreencontrol.rb
@@ -8,6 +8,10 @@ cask 'lg-onscreencontrol' do
 
   pkg "OnScreenControl_V#{version}.pkg"
 
-  uninstall quit:    'com.LGSI.-.OnScreen-Control',
-            pkgutil: 'com.lge.onscreenControl.*'
+  uninstall login_item: 'OnScreen Control',
+            pkgutil:    [
+                          'com.lge.onscreenControl.*',
+                          'com.lge.OnscreenControl.*',
+                        ],
+            quit:       'com.LGSI.OnScreen-Control'
 end


### PR DESCRIPTION
*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
jeremy.gaither@ip-192-168-26-124:homebrew-drivers (jeremygaither/jeremygaither-patch/lg_onscreencontrol)$ brew cask audit --download lg-onscreencontrol
==> Downloading http://www.lg.com/us/lgecs.downloadFile.ldwf?DOC_ID=20150320442554&what=MANUAL&fromSystem=LG.COM&fileId=q0YuHZx6oufr
Already downloaded: /Users/jeremy.gaither/Library/Caches/Homebrew/Cask/lg-onscreencontrol--2.46.zip
==> Verifying checksum for Cask lg-onscreencontrol
audit for lg-onscreencontrol: passed

- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.
Edits made online
