### PR TITLE
Update garmin-virb-edit to 5.1.1

### DIFF
--- a/Casks/bragi-updater.rb
+++ b/Casks/bragi-updater.rb
@@ -4,7 +4,7 @@ cask 'bragi-updater' do
 
   url "http://update.bragi.com/bin/Bragi%20Updater-#{version}.dmg"
   appcast 'http://update.bragi.com/',
-          checkpoint: '21eaf7775f39fcfe8ea03a60fd9032805829cb15b13a3bb9de96ae44da156e73'
+          checkpoint: '400f9e0c852450239d75eaf45445486a1e69cc4444cc8057d59167d5a5115648'
   name 'Bragi Updater'
   homepage 'http://update.bragi.com/'
 

--- a/Casks/bragi-updater.rb
+++ b/Casks/bragi-updater.rb
@@ -4,7 +4,7 @@ cask 'bragi-updater' do
 
   url "http://update.bragi.com/bin/Bragi%20Updater-#{version}.dmg"
   appcast 'http://update.bragi.com/',
-          checkpoint: '400f9e0c852450239d75eaf45445486a1e69cc4444cc8057d59167d5a5115648'
+          checkpoint: '21eaf7775f39fcfe8ea03a60fd9032805829cb15b13a3bb9de96ae44da156e73'
   name 'Bragi Updater'
   homepage 'http://update.bragi.com/'
 

--- a/Casks/garmin-virb-edit.rb
+++ b/Casks/garmin-virb-edit.rb
@@ -1,6 +1,6 @@
 cask 'garmin-virb-edit' do
-  version '5.1.0'
-  sha256 'ba573a2841c9fc34e9c88995bef54de7b42e9ff0c94bdd7d0b40615005b531f9'
+  version '5.1.1'
+  sha256 '53b108528b50ad430d704ed987e9eb7aebdaf79a561a393efe6e634a2924d4b2'
 
   url "http://download.garmin.com/software/VIRBEditforMac_#{version.no_dots}.dmg"
   name 'Garmin VIRB Edit'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}