### PR TITLE
Update synology-photo-station-uploader to 1.4.1-083

### DIFF
--- a/Casks/synology-photo-station-uploader.rb
+++ b/Casks/synology-photo-station-uploader.rb
@@ -1,6 +1,6 @@
 cask 'synology-photo-station-uploader' do
-  version '1.4-080'
-  sha256 '8b1e9477329d6f611df85ffcef715e289001a186e0f95ff0062b85104beaa83b'
+  version '1.4.1-083'
+  sha256 '89394fa8d268c74aba56ebf1fbd293c95f340b9750d16cbe14c6e675dd74726b'
 
   url "https://global.download.synology.com/download/Tools/PhotoStationUploader/#{version}/Mac/PhotoStationUploader-#{version.sub(%r{.*-}, '')}-Mac-Installer.dmg"
   name 'Synology Photo Station Uploader'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}