### PR TITLE
Synology Assistant 6.1-15030 has been renamed

### DIFF
--- a/Casks/synology-assistant.rb
+++ b/Casks/synology-assistant.rb
@@ -6,7 +6,7 @@ cask 'synology-assistant' do
   name 'Synology Assistant'
   homepage 'https://www.synology.com/'
 
-  app 'Synology Assistant.app'
+  app 'SynologyAssistant.app'
 
   zap delete: '~/Library/Preferences/com.synology.DSAssistant.plist'
 end


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

The app package seems to have been renamed from "Synology Assistant.app" to "SynologyAssistant.app".

Can easily be tested by trying to install it.
`brew cask install synology-assistant`

With the old name, install fails with:
```
Error: It seems the App source '/usr/local/Caskroom/synology-assistant/6.1-15030/Synology Assistant.app' is not there.
Error: Install incomplete.
```