### PR TITLE
Update logitech-options to 6.62.200

### DIFF
--- a/Casks/logitech-options.rb
+++ b/Casks/logitech-options.rb
@@ -1,6 +1,6 @@
 cask 'logitech-options' do
-  version '6.60.448'
-  sha256 '369134386fdac6d2a7ca994214054587e4536b9a562a6a6a87025225a9d675b7'
+  version '6.62.200'
+  sha256 '31bd682f811049b05137bfe813032dc5d8ed3c05c21609eb7945efdbd7329553'
 
   url "https://www.logitech.com/pub/techsupport/options/Options_#{version}.zip"
   name 'Logitech Options'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}