### PR TITLE
Update canon-imagerunner-printer-driver-ufrii to 10.13.01

### DIFF
--- a/Casks/canon-imagerunner-printer-driver-ufrii.rb
+++ b/Casks/canon-imagerunner-printer-driver-ufrii.rb
@@ -1,10 +1,10 @@
 cask 'canon-imagerunner-printer-driver-ufrii' do
-  version '10.13.00'
-  sha256 '6abf81344ad8544b3163d4387ebae549945d0801ee8443c1bdba54f00c8b0002'
+  version '10.13.01'
+  sha256 '7555870c9cf769cce49267b8cdd2e63fcec1e8a409ccbfeb3d12c7e3e67f211b'
 
   url "https://downloads.canon.com/bisg2017/drivers/mac/UFRII_v#{version}_Mac.zip"
   appcast 'https://www.usa.canon.com/internet/PA_NWSupport/driversDownloads?model=15802&os=MACOS_V10_12&type=DS&lang=English',
-          checkpoint: 'a9020c52b6f7f2f6cbef801c4594f31a09b9e8ab003f4e17a6fa60160e0d974d'
+          checkpoint: 'aed281f5c6c91a26ec1874f48868a9014da97748e5831ee012f0bf0445f5ab23'
   name 'Canon imageRUNNER UFRII Printer Driver'
   homepage 'https://www.usa.canon.com/internet/portal/us/home/support/details/copiers-mfps-fax-machines/support-multifunction/imagerunner-2018'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}