### PR TITLE
Update bose-soundtouch to 15.120.23-1440-a59673d,mr2_2017-c7dabc12

### DIFF
--- a/Casks/bose-soundtouch.rb
+++ b/Casks/bose-soundtouch.rb
@@ -1,9 +1,9 @@
 cask 'bose-soundtouch' do
-  version '14.80.6-708-9bd051b'
-  sha256 'e43759c8788dcfecae5af86f1f0d36231aa1ef09ebb0536f74dc101e345a5278'
+  version '15.120.23-1440-a59673d,mr2_2017-c7dabc12'
+  sha256 'd650b65a93bc56f0391b99568e7248d69429a9dd096224968d7e7ee87fcebf74'
 
   # bose.com was verified as official when first introduced to the cask
-  url "https://downloads.bose.com/ced/soundtouch/mr4_2016/SoundTouch-app-installer-#{version}.dmg"
+  url "https://downloads.bose.com/ced/soundtouch/#{version.after_comma}/SoundTouch-app-installer-#{version.before_comma}.dmg"
   appcast 'https://downloads.bose.com/ced/soundtouch/soundtouch_controller_app/index.html',
           checkpoint: '93458a17a19ac42e6f8cf9e925257a69618800daff8dfa9d698f6f6e7c6cae8e'
   name 'Bose Soundtouch Controller App'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}