### PR TITLE
Update synology-surveillance-station-client to 1.0.5-0232

### DIFF
--- a/Casks/synology-surveillance-station-client.rb
+++ b/Casks/synology-surveillance-station-client.rb
@@ -1,6 +1,6 @@
 cask 'synology-surveillance-station-client' do
-  version '1.0.3-0214'
-  sha256 '8a9ed4a817307307a3640a2e9bfc34e95a65aa929eef87b7e0f1f51cdd97eece'
+  version '1.0.5-0232'
+  sha256 '117ff0ffbdffe945297389980cc4744eb531949fe428cb7db3f20e7b4786f4e0'
 
   url "https://global.download.synology.com/download/Tools/SurveillanceStationClient/#{version}/Mac/Synology%20Surveillance%20Station%20Client-#{version}.dmg"
   name 'Synology Surveillance Station Client'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.