### PR TITLE
Update Unifi Controller to 5.5.20

### DIFF
--- a/Casks/unifi-controller.rb
+++ b/Casks/unifi-controller.rb
@@ -1,6 +1,6 @@
 cask 'unifi-controller' do
-  version '5.5.19'
-  sha256 'f3f3e94185cd43a1f21a4483afc161ebba5c905fd3680d26b159f3e97f741adc'
+  version '5.5.20'
+  sha256 'b66f51a501efe43452f903322047e23865d3300e643aec10488707486197daea'
 
   url "https://dl.ubnt.com/unifi/#{version}/UniFi.pkg"
   name 'UniFi Controller'


### PR DESCRIPTION
*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?][version-checksum]).  
      I’m providing public confirmation below.
