### PR TITLE
Update yubico-authenticator to 4.1.4

### DIFF
--- a/Casks/yubico-authenticator.rb
+++ b/Casks/yubico-authenticator.rb
@@ -1,10 +1,10 @@
 cask 'yubico-authenticator' do
-  version '4.1.2'
-  sha256 'd9f104a5631b6628b16eb996eaa3b33cdd9560ffc15b0098234b00d281b666c6'
+  version '4.1.4'
+  sha256 '3809983c05ac9dd2ce096d56660764c59a75ca1eaa876e3a8fa0e432c004c5b9'
 
   url "https://developers.yubico.com/yubioath-desktop/Releases/yubioath-desktop-#{version}-mac.pkg"
   appcast 'https://developers.yubico.com/yubioath-desktop/Release_Notes.html',
-          checkpoint: '089bbd0911df46721f3ddcd8a955729e45583bac92c35a3ab1e55837b4812952'
+          checkpoint: '3db0d9b5dd1c45fd7e37f9306e1dbd6e2e6f3e8f48527940a31efdc4fda5285a'
   name 'Yubico Authenticator'
   homepage 'https://developers.yubico.com/yubioath-desktop/'
 


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?][version-checksum]).  
      I’m providing public confirmation below.

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-drivers/pulls
[closed issues]: https://github.com/caskroom/homebrew-drivers/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
