### PR TITLE
Update silicon-labs-vcp-driver to latest

### DIFF
--- a/Casks/silicon-labs-vcp-driver.rb
+++ b/Casks/silicon-labs-vcp-driver.rb
@@ -1,10 +1,8 @@
 cask 'silicon-labs-vcp-driver' do
-  version '5.0'
-  sha256 '0bcf565fb9cc04292c116fe14e1ce26992defc614026b6e7d3c1e9797389430e'
+  version :latest
+  sha256 :no_check
 
   url 'https://www.silabs.com/documents/public/software/Mac_OSX_VCP_Driver.zip'
-  appcast 'https://www.silabs.com/documents/public/software/Mac_OSX_VCP_Driver_Release_Notes.txt',
-          checkpoint: '31e39181562c8a62b2cbf17bb0b64d40d3623bafd52d12fa527ba100997dac65'
   name 'Silicon Labs VCP Driver'
   name 'CP210x USB to UART Bridge VCP Driver'
   homepage 'https://www.silabs.com/products/development-tools/software/usb-to-uart-bridge-vcp-drivers'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.


`appcast` doesn't update so change to `latest` and `no_check`