### PR TITLE
Update logitech-options to 6.70.938

### DIFF
--- a/Casks/logitech-options.rb
+++ b/Casks/logitech-options.rb
@@ -1,6 +1,6 @@
 cask 'logitech-options' do
-  version '6.62.200'
-  sha256 '31bd682f811049b05137bfe813032dc5d8ed3c05c21609eb7945efdbd7329553'
+  version '6.70.938'
+  sha256 'e33b78cdf5ca8030732e055d8cbe8e449682761fef4f6428636e8679efaa4e6d'
 
   url "https://www.logitech.com/pub/techsupport/options/Options_#{version}.zip"
   name 'Logitech Options'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.