### PR TITLE
Update logitech-drivers - fix pkg version mismatch

### DIFF
--- a/Casks/logitech-options.rb
+++ b/Casks/logitech-options.rb
@@ -1,15 +1,15 @@
 cask 'logitech-options' do
-  version '6.70.938'
+  version '6.70.938,6.70.928'
   sha256 'e33b78cdf5ca8030732e055d8cbe8e449682761fef4f6428636e8679efaa4e6d'
 
-  url "https://www.logitech.com/pub/techsupport/options/Options_#{version}.zip"
+  url "https://www.logitech.com/pub/techsupport/options/Options_#{version.before_comma}.zip"
   name 'Logitech Options'
   homepage 'https://support.logitech.com/en_us/software/options'
 
   auto_updates true
   depends_on macos: '>= :mavericks'
 
-  pkg "LogiMgr Installer #{version}.app/Contents/Resources/LogiMgr.mpkg"
+  pkg "LogiMgr Installer #{version.after_comma}.app/Contents/Resources/LogiMgr.mpkg"
 
   uninstall script:  {
                        executable: '/Applications/Utilities/LogiMgr Uninstaller.app/Contents/Resources/Uninstaller',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

https://github.com/caskroom/homebrew-drivers/issues/137