### PR TITLE
Update garmin-virb-edit to 5.1.3

### DIFF
--- a/Casks/garmin-virb-edit.rb
+++ b/Casks/garmin-virb-edit.rb
@@ -1,6 +1,6 @@
 cask 'garmin-virb-edit' do
-  version '5.1.2'
-  sha256 'f0c0fc9024fd96fab0596deb0ec3085d2a0e0d1e074eaf2835852181e41bb2c0'
+  version '5.1.3'
+  sha256 '8bd79d4efdbb641c54b2a7f6044dcd9f2fb6cefb79e5431651af85be7df3cfa2'
 
   url "http://download.garmin.com/software/VIRBEditforMac_#{version.no_dots}.dmg"
   name 'Garmin VIRB Edit'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.