### PR TITLE
Update bose-soundtouch to 15.120.23-1440-a59673d,mr2_2017-c7dabc12

### DIFF
--- a/Casks/bose-soundtouch.rb
+++ b/Casks/bose-soundtouch.rb
@@ -9,6 +9,7 @@ cask 'bose-soundtouch' do
   name 'Bose Soundtouch Controller App'
   homepage 'https://www.soundtouch.com/'
 
+  auto_updates true
   depends_on macos: '>= :mavericks'
 
   installer script: {


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.