### PR TITLE
Add Navdy 1.0.146

### DIFF
--- a/Casks/navdy.rb
+++ b/Casks/navdy.rb
@@ -2,17 +2,15 @@ cask 'navdy' do
   version '1.0.146'
   sha256 'f30f84016e435239cc2ca63a8ed5b43ec858c815310cfbfa147cea9bb4f940c4'
 
-  url 'https://downloads.navdy.com/desktop_support/release/navdy_desktop_mac.dmg'
+  url "https://downloads.navdy.com/desktop_support/release/navdy_desktop_mac_#{version}.dmg"
   name 'Navdy'
   homepage 'https://navdy.zendesk.com/hc/en-us/articles/115001590703'
 
   app 'Navdy.app'
 
   zap delete: [
-                '~/Library/Application Support/Navdy',
+                '~/Library/Saved Application State/com.navdy.application.desktop.savedState',
                 '~/Library/Preferences/com.navdy.application.desktop.plist',
               ],
-      trash:  [
-                '~/Library/Saved Application State/com.navdy.application.desktop.savedState',
-              ]
+      trash:  '~/Library/Application Support/Navdy'
 end

--- a/Casks/navdy.rb
+++ b/Casks/navdy.rb
@@ -2,15 +2,16 @@ cask 'navdy' do
   version '1.0.146'
   sha256 'f30f84016e435239cc2ca63a8ed5b43ec858c815310cfbfa147cea9bb4f940c4'
 
+  # downloads.navdy.com/desktop_support/release was verified as official when first introduced to the cask
   url "https://downloads.navdy.com/desktop_support/release/navdy_desktop_mac_#{version}.dmg"
   name 'Navdy'
   homepage 'https://navdy.zendesk.com/hc/en-us/articles/115001590703'
 
   app 'Navdy.app'
 
-  zap delete: [
-                '~/Library/Saved Application State/com.navdy.application.desktop.savedState',
+  zap delete: '~/Library/Saved Application State/com.navdy.application.desktop.savedState',
+      trash:  [
+                '~/Library/Application Support/Navdy',
                 '~/Library/Preferences/com.navdy.application.desktop.plist',
-              ],
-      trash:  '~/Library/Application Support/Navdy'
+              ]
 end

--- a/Casks/navdy.rb
+++ b/Casks/navdy.rb
@@ -1,0 +1,18 @@
+cask 'navdy' do
+  version '1.0.146'
+  sha256 'f30f84016e435239cc2ca63a8ed5b43ec858c815310cfbfa147cea9bb4f940c4'
+
+  url 'https://downloads.navdy.com/desktop_support/release/navdy_desktop_mac.dmg'
+  name 'Navdy'
+  homepage 'https://navdy.zendesk.com/hc/en-us/articles/115001590703'
+
+  app 'Navdy.app'
+
+  zap delete: [
+                '~/Library/Application Support/Navdy',
+                '~/Library/Preferences/com.navdy.application.desktop.plist',
+              ],
+      trash:  [
+                '~/Library/Saved Application State/com.navdy.application.desktop.savedState',
+              ]
+end


### PR DESCRIPTION
Desktop application used to update offline maps on a [Navdy](https://www.navdy.com/) (heads-up display for a car). I poked around a little looking for a versioned download URL but couldn't find one.

---

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-drivers/pulls
[closed issues]: https://github.com/caskroom/homebrew-drivers/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
