### PR TITLE
Update eyetv to 3.6.9,7520:20170730

### DIFF
--- a/Casks/eyetv.rb
+++ b/Casks/eyetv.rb
@@ -1,11 +1,11 @@
 cask 'eyetv' do
-  version '3.6.9_7518'
-  sha256 'f6108cd5c2d6626c40b21e01b585d8a4f4a681cffd39b236376fce618133e974'
+  version '3.6.9,7520:20170730'
+  sha256 '41c092b92dd7470095d1748dde357de76f2331bd5e142f33d2aa3865fb5ce7a5'
 
   # file.geniatech.com/eyetv3 was verified as official when first introduced to the cask
-  url "http://file.geniatech.com/eyetv3/EyeTV#{version}.dmg"
+  url "http://file.geniatech.com/eyetv3/EyeTV#{version.before_comma}(#{version.before_colon.after_comma})#{version.after_colon}.dmg"
   appcast "https://www.geniatech.eu/eyetv/support/eyetv-#{version.major}-en/",
-          checkpoint: '3e6674a84a0329cf38da68c4de888af358441c11235913ae0dfa968b98de763e'
+          checkpoint: '99594ce7d7f905c2d8e533ca6d888e0ae3aa2d22a26a7382f35c9d4ce893c76a'
   name 'EyeTV'
   homepage 'https://www.geniatech.eu/eyetv/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.