### PR TITLE
Update DisplayLink to version 4.0.0

### DIFF
--- a/Casks/displaylink.rb
+++ b/Casks/displaylink.rb
@@ -1,6 +1,6 @@
 cask 'displaylink' do
   version '4.0,1033'
-  sha256 '9b0948cc1a15e68ef3a7ea559fa4b0ff6db7d93e62eaa531064f4de914e2f210'
+  sha256 'd80a428b1aa62d8b1c31362dd848c588016c80cf53fd3b735c5a538ed5e89a73'
 
   url "http://www.displaylink.com/downloads/file?id=#{version.after_comma}",
       data:  {

--- a/Casks/displaylink.rb
+++ b/Casks/displaylink.rb
@@ -1,6 +1,6 @@
 cask 'displaylink' do
-  version '3.1,776'
-  sha256 'ac7e64fc020650842b7f4c13bbfb44f513dfd7e5b934174b4339f1440e887e85'
+  version '4.0,1033'
+  sha256 '9b0948cc1a15e68ef3a7ea559fa4b0ff6db7d93e62eaa531064f4de914e2f210'
 
   url "http://www.displaylink.com/downloads/file?id=#{version.after_comma}",
       data:  {


### PR DESCRIPTION
After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Release Notes are available here:
http://assets.displaylink.com/live/downloads/release-notes/f1034_%09DisplayLink+USB+Graphics+Software+for+OS+X+and+macOS+4.0.0-Release+Notes.txt