### PR TITLE
Add Yubikey Manager 0.3.1

### DIFF
--- a/Casks/yubikey-manager.rb
+++ b/Casks/yubikey-manager.rb
@@ -1,0 +1,14 @@
+cask 'yubikey-manager' do
+  version '0.3.1'
+  sha256 '55190b911e44a106b5b6f288a0ccdbd853d82e1c47ef0efd1029ef8dd24b5630'
+
+  url "https://developers.yubico.com/yubikey-manager-qt/Releases/yubikey-manager-qt-#{version}-mac.pkg"
+  appcast 'https://developers.yubico.com/yubikey-manager-qt/Release_Notes.html',
+          checkpoint: '049557d1ee8dad39dbe2a2a50605219d261dedf0d54c96099c73c1643cea2a9f'
+  name 'Yubikey Manager'
+  homepage 'https://developers.yubico.com/yubikey-manager/'
+
+  pkg "yubikey-manager-qt-#{version}-mac.pkg"
+
+  uninstall pkgutil: 'com.yubico.ykman'
+end


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-cask/pulls
[closed issues]: https://github.com/caskroom/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256

-------

This new cask supersede the old `Yubikey Neo Manager` (`yubikey-neo-manager.rb`) which has been deprecated (see Developer Note at https://developers.yubico.com/yubikey-neo-manager/). This is the new manager tool that replaces it.

Should I add the removal of the old cask in this PR ?