### PR TITLE
Updated nvidia-web-driver to 378.10.10.10.15.114

### DIFF
--- a/Casks/nvidia-web-driver.rb
+++ b/Casks/nvidia-web-driver.rb
@@ -1,10 +1,16 @@
 cask 'nvidia-web-driver' do
-  version '378.10.10.10.15.114'
-  sha256 '02fafe29be21923ea9f647a9075171b37b2714a8f59cc28570b52311240e6ebb'
+  if MacOS.version <= :sierra
+    version '378.05.05.25f01'
+    sha256 '79b831457e0ba0b7f99ee69f49f1abcd106446713bfa2ffc09e4058b4dec501d'
+    url "http://us.download.nvidia.com/Mac/Quadro_Certified/#{version}/WebDriver-#{version}.pkg"
+  else
+    version '378.10.10.10.15.114'
+    sha256 '02fafe29be21923ea9f647a9075171b37b2714a8f59cc28570b52311240e6ebb'
+    url "http://us.download.nvidia.com/Mac/Quadro_Certified/#{version[0..14]}/WebDriver-#{version}.pkg"
+  end
 
-  url "http://us.download.nvidia.com/Mac/Quadro_Certified/#{version[0..14]}/WebDriver-#{version}.pkg"
   name 'NVIDIA Web Driver'
-  homepage 'https://www.nvidia.com/download/driverResults.aspx/107369/en-us'
+  homepage 'http://www.nvidia.com/download/driverResults.aspx/125379/en-us'
 
   pkg "WebDriver-#{version}.pkg"
 

--- a/Casks/nvidia-web-driver.rb
+++ b/Casks/nvidia-web-driver.rb
@@ -1,8 +1,8 @@
 cask 'nvidia-web-driver' do
-  version '378.05.05.25f01'
-  sha256 '79b831457e0ba0b7f99ee69f49f1abcd106446713bfa2ffc09e4058b4dec501d'
+  version '378.10.10.10.15.114'
+  sha256 '02fafe29be21923ea9f647a9075171b37b2714a8f59cc28570b52311240e6ebb'
 
-  url "http://us.download.nvidia.com/Mac/Quadro_Certified/#{version}/WebDriver-#{version}.pkg"
+  url "http://us.download.nvidia.com/Mac/Quadro_Certified/#{version[0..14]}/WebDriver-#{version}.pkg"
   name 'NVIDIA Web Driver'
   homepage 'https://www.nvidia.com/download/driverResults.aspx/107369/en-us'
 


### PR DESCRIPTION
**Note** Updated version but had to patch url pattern because last minor version number wasn't postfixed to download folder in url. This will need to be changed when next update is rolled out. 

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
