### PR TITLE
Update synology-cloud-station-backup to 4.2.5-4396

### DIFF
--- a/Casks/synology-cloud-station-backup.rb
+++ b/Casks/synology-cloud-station-backup.rb
@@ -1,6 +1,6 @@
 cask 'synology-cloud-station-backup' do
-  version '4.2.3-4385'
-  sha256 '5e8bbf41dee07cd1c124c24523958a3d60e6960c8bf5ba9a367e7eb8c2f2dbc2'
+  version '4.2.5-4396'
+  sha256 '420784b2defc921f4072f4f2577b413a4e6462cac74a4cc298e5109b0ccf5a57'
 
   url "https://global.download.synology.com/download/Tools/CloudStationBackup/#{version}/Mac/Installer/synology-cloud-station-backup-#{version.sub(%r{.*-}, '')}.dmg"
   name 'Synology Cloud Station Backup'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.