### PR TITLE
Update lg-onscreencontrol to 2.55

### DIFF
--- a/Casks/lg-onscreencontrol.rb
+++ b/Casks/lg-onscreencontrol.rb
@@ -1,8 +1,8 @@
 cask 'lg-onscreencontrol' do
-  version '2.46'
-  sha256 '943cfd2d59d56b47ae244d175eaa4344cb49e5e39a4efd812ba78939970e69e8'
+  version '2.55'
+  sha256 '07706253f8279557f3f7d8a13392bf5f565b257445a6353936826bd246f1925d'
 
-  url "http://www.lg.com/us/lgecs.downloadFile.ldwf?DOC_ID=20150320442554&what=MANUAL&fromSystem=LG.COM&fileId=q0YuHZx6oufr6zJ6znVLmg&ORIGINAL_NAME_b1_a1=MAC_OSC.#{version}.zip"
+  url "https://www.lg.com/us/lgecs.downloadFile.ldwf?DOC_ID=20150320442554&what=MANUAL&fromSystem=LG.COM&fileId=x73htvfcBHcxPZb8AT82ug&ORIGINAL_NAME_b1_a1=Mac_OSC_#{version}.zip"
   name 'LG OnScreen Control'
   homepage 'http://www.lg.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.

---

Closes #171.