### PR TITLE
Update netgeargenie to 2.4.22(2017-1-17)

### DIFF
--- a/Casks/netgeargenie.rb
+++ b/Casks/netgeargenie.rb
@@ -1,6 +1,6 @@
 cask 'netgeargenie' do
   version '2.4.22(2017-1-17)'
-  sha256 'fddb83c7f8ccb6b46a7768acbd260f631c2913440b725e5db39f7e8041e54907'
+  sha256 '41e360d92a61502aa9ea575356153d637d2a96ded0b190004d0493f1601245db'
 
   url 'http://updates1.netgear.com/netgeargenie/mac/update/NETGEARGenieInstaller.dmg'
   name 'NETGEARGenie'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [x] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.

While there is no *Signature Info* section in the VirusTotal report, and there isn't a public developer confirmation, the official website (at [https://www.netgear.com/home/discover/apps/genie.aspx](https://www.netgear.com/home/discover/apps/genie.aspx)) provides this download and the checksum is produced from this download. This likely means the app was updated in place.