### PR TITLE
Update Razer Synapse.app to 1.79

### DIFF
--- a/Casks/razer-synapse.rb
+++ b/Casks/razer-synapse.rb
@@ -1,12 +1,20 @@
 cask 'razer-synapse' do
-  version '1.78'
-  sha256 '10e8ade53bafb392c0a5848d8948d7643c9501877870f2b920b85ebf0eac4adf'
+  if MacOS.version >= :mavericks
+    version '1.79'
+    sha256 '706be1158e398485de73ed61086518c27e74e5645dd85ef3ace6cc1bf5caec3e'
+  elsif MacOS.version == :mountain_lion
+    version '1.49'
+    sha256 'dd828cc5ab7e3cdcdd5288283888f5010de2b33a9747eed72d17269acf05e7bf'
+  elsif MacOS.version <= :lion
+    version '1.34'
+    sha256 'b1e8db46d58942468625ce2723a92bfd607fb6b94f1b7ad7797e36f7bb74b9d1'
+  end
 
   url "http://dl.razerzone.com/drivers/Synapse2/mac/Razer_Synapse_Mac_Driver_v#{version}.dmg"
   name 'Razer Synapse'
   homepage 'https://www.razerzone.com/synapse/'
 
-  depends_on macos: '>= :lion'
+  depends_on macos: '>= :snow_leopard'
 
   pkg 'Razer Synapse.pkg'
 


### PR DESCRIPTION
This also includes changes for mapping to the correct version of OS X.

For reference
http://drivers.razersupport.com/index.php?_m=downloads&_a=view&parentcategoryid=239&pcid=0&nav=0&_m=downloads&_a=view&parentcategoryid=239&pcid=0&nav=0