### PR TITLE
Update bassjump to 3.1.0

### DIFF
--- a/Casks/bassjump.rb
+++ b/Casks/bassjump.rb
@@ -20,7 +20,11 @@ cask 'bassjump' do
 
   depends_on macos: '>= :mavericks'
 
-  pkg 'BassJumpInstaller.pkg'
+  if MacOS.version <= :el_capitan
+    pkg 'BassJumpInstaller.pkg'
+  else
+    pkg 'BassJump Installer.pkg'
+  end
 
   uninstall pkgutil:    [
                           'com.twelvesouth.bassjump.installer.halplugin',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating only the `sha256`**:

- [ ] I verified this change is legitimate [<sup>How do I do that?</sup>](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256) and **am providing confirmation below**:

---

Closes #185.