### PR TITLE
Update nvidia-web-driver to 378.10.10.10.15.117

### DIFF
--- a/Casks/nvidia-web-driver.rb
+++ b/Casks/nvidia-web-driver.rb
@@ -4,8 +4,8 @@ cask 'nvidia-web-driver' do
     sha256 '79b831457e0ba0b7f99ee69f49f1abcd106446713bfa2ffc09e4058b4dec501d'
     url "http://us.download.nvidia.com/Mac/Quadro_Certified/#{version}/WebDriver-#{version}.pkg"
   else
-    version '378.10.10.10.15.114'
-    sha256 '02fafe29be21923ea9f647a9075171b37b2714a8f59cc28570b52311240e6ebb'
+    version '378.10.10.10.15.117'
+    sha256 '79b831457e0ba0b7f99ee69f49f1abcd106446713bfa2ffc09e4058b4dec501d'
     url "http://us.download.nvidia.com/Mac/Quadro_Certified/#{version[0..14]}/WebDriver-#{version}.pkg"
   end
 

--- a/Casks/nvidia-web-driver.rb
+++ b/Casks/nvidia-web-driver.rb
@@ -2,15 +2,14 @@ cask 'nvidia-web-driver' do
   if MacOS.version <= :sierra
     version '378.05.05.25f01'
     sha256 '79b831457e0ba0b7f99ee69f49f1abcd106446713bfa2ffc09e4058b4dec501d'
-    url "http://us.download.nvidia.com/Mac/Quadro_Certified/#{version}/WebDriver-#{version}.pkg"
   else
     version '378.10.10.10.15.117'
-    sha256 '79b831457e0ba0b7f99ee69f49f1abcd106446713bfa2ffc09e4058b4dec501d'
-    url "http://us.download.nvidia.com/Mac/Quadro_Certified/#{version[0..14]}/WebDriver-#{version}.pkg"
+    sha256 '9fe60527f3c93b1699505c6447567e8677120ef204bfc35ec0668b3a48edf4bc'
   end
 
+  url "http://us.download.nvidia.com/Mac/Quadro_Certified/#{version}/WebDriver-#{version}.pkg"
   name 'NVIDIA Web Driver'
-  homepage 'http://www.nvidia.com/download/driverResults.aspx/125379/en-us'
+  homepage 'https://www.nvidia.com/Download/index.aspx'
 
   pkg "WebDriver-#{version}.pkg"
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.