### PR TITLE
Fix download url of AX88179 v.2.9.0_20171011

### DIFF
--- a/Casks/ax88179.rb
+++ b/Casks/ax88179.rb
@@ -1,10 +1,10 @@
 cask 'ax88179' do
-  version '2.9.0_20170426'
-  sha256 'c172aebb8d44c9d0edee3d06af74687a2da57042b9ddd4f2f604af5db4149882'
+  version '2.9.0_20171011'
+  sha256 '392d3db3c6e099c3a7dc349eaac88ffb1020e4514d2f860b24afcd3a5f32de03'
 
   module Utils
     def self.basename(version)
-      "AX88179_178A_Macintosh_10.6_to_10.12_Driver_Installer_v#{version}"
+      "AX88179_178A_Macintosh_Driver_Installer_v#{version}"
     end
   end
 

--- a/Casks/ax88179.rb
+++ b/Casks/ax88179.rb
@@ -34,7 +34,7 @@ cask 'ax88179' do
   end
 
   uninstall early_script: {
-                            executable: "#{staged_path}/AX88179_178A_Uninstall_v140",
+                            executable: "#{staged_path}/AX88179_178A_Uninstall_v150.command",
                           },
             kext:         'com.asix.driver.ax88179-178a',
             pkgutil:      'com.asix.pkg.ax88179-178a*'


### PR DESCRIPTION
Seems like they changed the filename of the installer, so I updated it.

---
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.