### PR TITLE
Update yubikey-manager to 0.3.1

### DIFF
--- a/Casks/yubikey-manager.rb
+++ b/Casks/yubikey-manager.rb
@@ -6,7 +6,7 @@ cask 'yubikey-manager' do
   appcast 'https://developers.yubico.com/yubikey-manager-qt/Release_Notes.html',
           checkpoint: '049557d1ee8dad39dbe2a2a50605219d261dedf0d54c96099c73c1643cea2a9f'
   name 'Yubikey Manager'
-  homepage 'https://developers.yubico.com/yubikey-manager/'
+  homepage 'https://developers.yubico.com/yubikey-manager-qt/'
 
   pkg "yubikey-manager-qt-#{version}-mac.pkg"
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating only the `sha256`**:

- [ ] I verified this change is legitimate [<sup>How do I do that?</sup>](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256) and **am providing confirmation below**: