### PR TITLE
Migrate 3 Casks from Caskroom

### DIFF
--- a/Casks/blackvue-viewer.rb
+++ b/Casks/blackvue-viewer.rb
@@ -1,6 +1,6 @@
 cask 'blackvue-viewer' do
-  version '1.10,74331'
-  sha256 '138e6db6dfa737fe4f00497d5296eb5464e888181979e83511d218ba0b5106e6'
+  version '1.13,74331'
+  sha256 '0eee70b2492d029fc959cb560d44be110f11355b9644f9e1930c2dba0d00326d'
 
   url "https://www.blackvue.com/download/blackvue-mac-viewer-cloud/?wpdmdl=#{version.after_comma}"
   name 'BlackVue Viewer'

--- a/Casks/blackvue-viewer.rb
+++ b/Casks/blackvue-viewer.rb
@@ -1,0 +1,10 @@
+cask 'blackvue-viewer' do
+  version '1.10,74331'
+  sha256 '138e6db6dfa737fe4f00497d5296eb5464e888181979e83511d218ba0b5106e6'
+
+  url "https://www.blackvue.com/download/blackvue-mac-viewer-cloud/?wpdmdl=#{version.after_comma}"
+  name 'BlackVue Viewer'
+  homepage 'https://www.blackvue.com/'
+
+  app 'BlackVue Viewer.app'
+end

--- a/Casks/discovercare.rb
+++ b/Casks/discovercare.rb
@@ -1,0 +1,23 @@
+cask 'discovercare' do
+  version '1.0.4'
+
+  language 'en', default: true do
+    sha256 '4f536f7e1c92787ee8a750fd4245c1d64c163807fb683ea8a59427aac57c18af'
+    'en'
+  end
+
+  language 'de' do
+    sha256 '1368c12cd3fa8fd0baef6cbcb9d130205778c4d249498422737b854b41b8f996'
+    'de'
+  end
+
+  url "http://en.volkswagen.com/content/medialib/vwd4/global/discovercare/files/discovercare_mac#{language}/_jcr_content/renditions/rendition.download_attachment.file/discovercare_mac_#{language}.zip"
+  name 'Volkswagen DiscoverCare'
+  homepage 'http://www.volkswagen.com/discovercare'
+
+  container nested: "DiscoverCare_v.#{version}.dmg"
+
+  app 'DiscoverCare.app'
+
+  zap trash: '~/DiscoverCare'
+end

--- a/Casks/nrf5x-command-line-tools.rb
+++ b/Casks/nrf5x-command-line-tools.rb
@@ -1,0 +1,11 @@
+cask 'nrf5x-command-line-tools' do
+  version '53406.17.93573317'
+  sha256 '19c918e8fa44964d570721b204bf460451eabbc90030ccdc5f1eeb6513a0ace1'
+
+  url "https://www.nordicsemi.com/eng/nordic/download_resource/#{version.major}/#{version.minor}/#{version.patch}"
+  name 'nRF5x Command Line Tools'
+  homepage 'https://www.nordicsemi.com/eng/nordic/Products/nRF51-DK/nRF5x-Command-Line-Tools-OSX/53412'
+
+  binary 'nrfjprog/nrfjprog'
+  binary 'mergehex/mergehex'
+end


### PR DESCRIPTION
https://github.com/caskroom/homebrew-cask/pull/39755

- blackvue-viewer
- discovercare
- nrf5x-command-line-tools
____
- update blackvue-viewer to 1.13,74331

> https://www.blackvue.com/download/blackvue-mac-viewer-cloud/