### PR TITLE
Update silicon-labs-vcp-driver to 5.0.2

### DIFF
--- a/Casks/silicon-labs-vcp-driver.rb
+++ b/Casks/silicon-labs-vcp-driver.rb
@@ -1,10 +1,10 @@
 cask 'silicon-labs-vcp-driver' do
-  version '5.0.1'
-  sha256 'c9b07213e9e67cc011999bf5f5a0c4e7fd38a1ca8015d942e160e9b7cf936345'
+  version '5.0.2'
+  sha256 '23bdc96d9ab4bb867b8cf3671451f8048e3c14f817b0970d76f430a87e7555f3'
 
   url 'https://www.silabs.com/documents/public/software/Mac_OSX_VCP_Driver.zip'
   appcast 'https://www.silabs.com/documents/public/software/Mac_OSX_VCP_Driver_Release_Notes.txt',
-          checkpoint: '81f97ce562b2bcc93c9d23a1481e0e610a03c9afe43cd7e70c8eb34b654ea8bf'
+          checkpoint: 'a9a1e44e9fe3b8690e26e94b10bd38ea3f903c8e89239960cc1f950d2355739c'
   name 'Silicon Labs VCP Driver'
   name 'CP210x USB to UART Bridge VCP Driver'
   homepage 'https://www.silabs.com/products/development-tools/software/usb-to-uart-bridge-vcp-drivers'


### PR DESCRIPTION
Update silicon-labs-vcp-driver to 5.0.2

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.