### PR TITLE
Rename *printerdrivers to apple-*printerdrivers

### DIFF
--- a/Casks/apple-brotherprinterdrivers.rb
+++ b/Casks/apple-brotherprinterdrivers.rb
@@ -1,4 +1,4 @@
-cask 'brotherprinterdrivers' do
+cask 'apple-brotherprinterdrivers' do
   version '4.1.1'
   sha256 '4f12496a351ecf2da717239c4c85a311401ddd465a036f4c175cfcc74abf58f6'
 

--- a/Casks/apple-hewlettpackardprinterdrivers.rb
+++ b/Casks/apple-hewlettpackardprinterdrivers.rb
@@ -1,4 +1,4 @@
-cask 'hewlettpackardprinterdrivers' do
+cask 'apple-hewlettpackardprinterdrivers' do
   version '5.0'
   sha256 '02aba5aacbc812d995a3818a1b032f5b1e6aa124060ed5405f0e73d8be726667'
 

--- a/Casks/apple-samsungprinterdrivers.rb
+++ b/Casks/apple-samsungprinterdrivers.rb
@@ -1,4 +1,4 @@
-cask 'samsungprinterdrivers' do
+cask 'apple-samsungprinterdrivers' do
   version '2.6'
   sha256 'ecf283ff40df816e84d3a6148676114d2b4fe3f4074feb995c2c7e0be8be4964'
 


### PR DESCRIPTION
@vitorgalvao This is a unusual case, the vendor is Apple. The manufacturer also provides drivers.