### PR TITLE
Rename xbox360-controller-driver: add unofficial

### DIFF
--- a/Casks/xbox360-controller-driver-unofficial.rb
+++ b/Casks/xbox360-controller-driver-unofficial.rb
@@ -1,10 +1,10 @@
-cask 'xbox360-controller-driver' do
+cask 'xbox360-controller-driver-unofficial' do
   version '0.16.5'
   sha256 '1e18fcb18e44072dcebecdadaeb1208df6425a4b4dc490df2883fcc60b0fa1c4'
 
   url "https://github.com/360Controller/360Controller/releases/download/v#{version}/360ControllerInstall_#{version}.dmg"
   appcast 'https://github.com/360Controller/360Controller/releases.atom',
-          checkpoint: '8da38cd097a881a013fb9235260286b553d5177920eef48a096df1447b2dd546'
+          checkpoint: '7fb3293a83c8cd981e3cfc6e4d9bbfdf091f7702804547730bec2b057405b410'
   name 'TattieBogle Xbox 360 Controller Driver (with improvements)'
   homepage 'https://github.com/360Controller/360Controller'
 


### PR DESCRIPTION
> The Tattiebogle driver is NOT the same driver as this Github project.