### PR TITLE
Add Brother QL-720NW label printer utilities and labeling app

### DIFF
--- a/Casks/brother-p-touch-editor.rb
+++ b/Casks/brother-p-touch-editor.rb
@@ -1,0 +1,15 @@
+cask 'brother-p-touch-editor' do
+  version '5.1.109'
+  sha256 'a1ecebc4688e5d44e5ca761501387f77c092ae96ed4dbc6fe5c6ce242fdf76af'
+
+  url "https://download.brother.com/pub/com/ptouch-su/editor/pem#{version.no_dots}x12us.dmg"
+  name 'Brother P-Touch Editor'
+  homepage 'http://www.brother.com/product/dev/label/editor/index.htm'
+
+  pkg "BrotherPtEdit#{version.major}.pkg"
+
+  uninstall pkgutil: [
+                       "com.brother.P-touchEditor#{version.major}.pkg",
+                       'com.brother.brotherptdriver.BrotherFonts_Common.pkg',
+                     ]
+end

--- a/Casks/brother-p-touch-update-software.rb
+++ b/Casks/brother-p-touch-update-software.rb
@@ -1,0 +1,12 @@
+cask 'brother-p-touch-update-software' do
+  version '1.4.7'
+  sha256 'e2f098562e23d85bc446e288a73f1b4e45482bb553f6fee0b889b06aee9907ce'
+
+  url "https://download.brother.com/welcome/dlfp100352/pum#{version.no_dots}x12all.dmg"
+  name 'Brother P-touch Update Software'
+  homepage 'http://support.brother.com/g/b/downloadhowto.aspx?c=us&lang=en&prod=lpql720nweus&os=10017&dlid=dlfp100352_000&flang=178&type3=10183'
+
+  pkg 'BrotherPtUpdateSoftware.pkg'
+
+  uninstall pkgutil: 'com.brother.brotherptdriver.BrotherPtUpdateSoftware'
+end

--- a/Casks/brother-ql720nw-utility.rb
+++ b/Casks/brother-ql720nw-utility.rb
@@ -1,0 +1,12 @@
+cask 'brother-ql720nw-utility' do
+  version '3.0.0'
+  sha256 '7a4dc1b0bc84c1eb32c0f97907d49051863a5fd4a06da064b881545264253984'
+
+  url "https://download.brother.com/welcome/dlfp100401/pst720m#{version.no_dots}x12all.dmg"
+  name 'Brother QL-720NW Printer Setting Tool'
+  homepage 'http://support.brother.com/g/b/producttop.aspx?c=us_ot&lang=en&prod=lpql720nweus'
+
+  pkg 'BrotherQL720NWUtility.pkg'
+
+  uninstall pkgutil: 'com.brother.brotherptdriver.BrotherQL720NWUtility.pkg'
+end

--- a/Casks/brother-ql720nw-wireless-setup-wizard.rb
+++ b/Casks/brother-ql720nw-wireless-setup-wizard.rb
@@ -1,0 +1,10 @@
+cask 'brother-ql720nw-wireless-setup-wizard' do
+  version '1.0.2'
+  sha256 '7436a3679ea6eb8300b1213ab2cd4d197a31ce9cf551015e96737f599fa0e997'
+
+  url "https://download.brother.com/welcome/dlfp100147/brotherwdsw_ql720nw_#{version.no_dots}.dmg"
+  name 'Brother QL-720NW Wireless Setup Wizard'
+  homepage 'http://support.brother.com/g/b/producttop.aspx?c=us_ot&lang=en&prod=lpql720nweus'
+
+  app 'Utilities/SetupWizard.app', target: 'Brother QL-720NW Wireless Setup Wizard.app'
+end


### PR DESCRIPTION
P-touch Editor is a labeling application which can be used with other Brother
label printers, but useless without one, so it is submitted to the drivers
repository.

P-touch Update Software naming is unfortunate: it updates both label printer
firmware (useful), and P-touch Editor (dubious).

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.

Additionally, if **adding a new cask**:

- [X] Named the cask according to the [token reference].
- [X] `brew cask install {{cask_file}}` worked successfully.
- [X] `brew cask uninstall {{cask_file}}` worked successfully.
- [X] Checked there are no [open pull requests] for the same cask.
- [X] Checked the cask was not already refused in [closed issues].
- [X] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-drivers/pulls
[closed issues]: https://github.com/caskroom/homebrew-drivers/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
