### PR TITLE
Update apple-hewlettpackardprinterdrivers to 5.1

### DIFF
--- a/Casks/apple-hewlettpackardprinterdrivers.rb
+++ b/Casks/apple-hewlettpackardprinterdrivers.rb
@@ -1,8 +1,8 @@
 cask 'apple-hewlettpackardprinterdrivers' do
-  version '5.0'
-  sha256 '02aba5aacbc812d995a3818a1b032f5b1e6aa124060ed5405f0e73d8be726667'
+  version '5.1'
+  sha256 '788e26e8afbfcf03d36f45e8563b1cd24183d6a8772b995914072189a714bd22'
 
-  url "http://support.apple.com/downloads/DL1888/en_US/hpprinterdrivers#{version}.dmg"
+  url "http://support.apple.com/downloads/DL1888/en_US/HewlettPackardPrinterDrivers#{version}.dmg"
   name 'HP Printer Drivers'
   homepage 'https://support.apple.com/kb/DL1888'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.