### PR TITLE
Update nvidia-web-driver to 378.10.10.10.15.121

### DIFF
--- a/Casks/nvidia-web-driver.rb
+++ b/Casks/nvidia-web-driver.rb
@@ -3,8 +3,8 @@ cask 'nvidia-web-driver' do
     version '378.05.05.25f01'
     sha256 '79b831457e0ba0b7f99ee69f49f1abcd106446713bfa2ffc09e4058b4dec501d'
   else
-    version '378.10.10.10.15.120'
-    sha256 '9cc83151eb29208e8a56f6b908bd23835522a1b38a51158a2b91f361bd217c0b'
+    version '378.10.10.10.15.121'
+    sha256 'ddb6f92a3a69420b35409616dda3cf130f89397b946e9ace21128e17d79c3465'
   end
 
   url "http://us.download.nvidia.com/Mac/Quadro_Certified/#{version}/WebDriver-#{version}.pkg"


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.