### PR TITLE
Update nvidia-web-driver to 378.10.10.10.20.107

### DIFF
--- a/Casks/nvidia-web-driver.rb
+++ b/Casks/nvidia-web-driver.rb
@@ -3,8 +3,8 @@ cask 'nvidia-web-driver' do
     version '378.05.05.25f01'
     sha256 '79b831457e0ba0b7f99ee69f49f1abcd106446713bfa2ffc09e4058b4dec501d'
   else
-    version '378.10.10.10.15.121'
-    sha256 'ddb6f92a3a69420b35409616dda3cf130f89397b946e9ace21128e17d79c3465'
+    version '378.10.10.10.20.107'
+    sha256 '85f949ba4137ed160f2e15ebb318ba22e83ccc99b3aedee319867d797f2aeaeb'
   end
 
   url "http://us.download.nvidia.com/Mac/Quadro_Certified/#{version}/WebDriver-#{version}.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.