### PR TITLE
Update kensington-trackball-works to 1.3.0

### DIFF
--- a/Casks/kensington-trackball-works.rb
+++ b/Casks/kensington-trackball-works.rb
@@ -1,9 +1,9 @@
 cask 'kensington-trackball-works' do
-  version '1.3'
+  version '1.3.0'
   sha256 '6c2271211f71fc80e237dad2a86f253b408e985d5aea58e574ac89f54e4ce1fc'
 
   # accoblobstorageus.blob.core.windows.net was verified as official when first introduced to the cask
-  url 'https://accoblobstorageus.blob.core.windows.net/software/38c915e6-ca92-406e-bd65-84e9692d4493.dmg'
+  url 'https://accoblobstorageus.blob.core.windows.net/software/97966e13-53b1-41e9-9c23-12a2c15dec5a.dmg'
   name 'Kensington TrackballWorks'
   homepage 'https://www.kensington.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.