### PR TITLE
Update silicon-labs-vcp-driver to 5.0.3

### DIFF
--- a/Casks/silicon-labs-vcp-driver.rb
+++ b/Casks/silicon-labs-vcp-driver.rb
@@ -1,10 +1,10 @@
 cask 'silicon-labs-vcp-driver' do
-  version '5.0.2'
-  sha256 '23bdc96d9ab4bb867b8cf3671451f8048e3c14f817b0970d76f430a87e7555f3'
+  version '5.0.3'
+  sha256 '638cc0091686d05c4afa189b345414687a0968b2c7414e993a974bb9f2177b62'
 
   url 'https://www.silabs.com/documents/public/software/Mac_OSX_VCP_Driver.zip'
   appcast 'https://www.silabs.com/documents/public/software/Mac_OSX_VCP_Driver_Release_Notes.txt',
-          checkpoint: 'a9a1e44e9fe3b8690e26e94b10bd38ea3f903c8e89239960cc1f950d2355739c'
+          checkpoint: '68261b79e248aa73c5fc9dd7772853ab05b79d04766c480836f68c1f0c683509'
   name 'Silicon Labs VCP Driver'
   name 'CP210x USB to UART Bridge VCP Driver'
   homepage 'https://www.silabs.com/products/development-tools/software/usb-to-uart-bridge-vcp-drivers'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.