### PR TITLE
Update ubiquiti-unifi-controller to 5.6.26

### DIFF
--- a/Casks/ubiquiti-unifi-controller.rb
+++ b/Casks/ubiquiti-unifi-controller.rb
@@ -1,6 +1,6 @@
 cask 'ubiquiti-unifi-controller' do
-  version '5.6.22'
-  sha256 '0481ec530f9bc1b51ea940bd3c89e57e12b84d2ab3c7c6376141337118b08729'
+  version '5.6.26'
+  sha256 'fab2a2b6c53dd90bd2aeb7a73b72ca60ff08f4fd12c031bbcfd5da995c0bec6b'
 
   url "https://dl.ubnt.com/unifi/#{version}/UniFi.pkg"
   name 'UniFi Controller'


### PR DESCRIPTION
https://community.ubnt.com/t5/UniFi-Updates-Blog/UniFi-5-6-26-Stable-has-been-released/ba-p/2165432

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
