### PR TITLE
Update nvidia-web-driver to 378.10.10.10.25.102

### DIFF
--- a/Casks/nvidia-web-driver.rb
+++ b/Casks/nvidia-web-driver.rb
@@ -1,17 +1,14 @@
 cask 'nvidia-web-driver' do
-  if MacOS.version <= :sierra
-    version '378.05.05.25f01'
-    sha256 '79b831457e0ba0b7f99ee69f49f1abcd106446713bfa2ffc09e4058b4dec501d'
-  else
-    version '378.10.10.10.25.102'
-    sha256 '5eca1fb15b5bf14083b54fcc667ab57353f0600503d3d9daa317dbfe8b3941af'
-  end
+  version '378.10.10.10.25.102'
+  sha256 '5eca1fb15b5bf14083b54fcc667ab57353f0600503d3d9daa317dbfe8b3941af'
 
-  url "https://images.nvidia.com/mac/pkg/378/WebDriver-#{version}.pkg"
+  url "https://images.nvidia.com/mac/pkg/#{version.major}/WebDriver-#{version}.pkg"
   appcast 'https://gfe.nvidia.com/mac-update',
           checkpoint: '9fd6c3b53687a3891ed1cbb6d52473e87039f6035bcfe85dae8df29c9a5a59c6'
   name 'NVIDIA Web Driver'
   homepage 'https://www.nvidia.com/Download/index.aspx'
+
+  depends_on macos: '>= :high_sierra'
 
   pkg "WebDriver-#{version}.pkg"
 

--- a/Casks/nvidia-web-driver.rb
+++ b/Casks/nvidia-web-driver.rb
@@ -3,11 +3,13 @@ cask 'nvidia-web-driver' do
     version '378.05.05.25f01'
     sha256 '79b831457e0ba0b7f99ee69f49f1abcd106446713bfa2ffc09e4058b4dec501d'
   else
-    version '378.10.10.10.20.109'
-    sha256 'e54f994f5be4a9b82d2f4df6b185299092c4e1390734cfa6a4cde478c179f626'
+    version '378.10.10.10.25.102'
+    sha256 '5eca1fb15b5bf14083b54fcc667ab57353f0600503d3d9daa317dbfe8b3941af'
   end
 
-  url "http://us.download.nvidia.com/Mac/Quadro_Certified/#{version}/WebDriver-#{version}.pkg"
+  url "https://images.nvidia.com/mac/pkg/378/WebDriver-#{version}.pkg"
+  appcast 'https://gfe.nvidia.com/mac-update',
+          checkpoint: '9fd6c3b53687a3891ed1cbb6d52473e87039f6035bcfe85dae8df29c9a5a59c6'
   name 'NVIDIA Web Driver'
   homepage 'https://www.nvidia.com/Download/index.aspx'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.