### PR TITLE
Update bose-soundtouch to 17.170.80-1819-25804d2,mr4_2017_73e7b563

### DIFF
--- a/Casks/bose-soundtouch.rb
+++ b/Casks/bose-soundtouch.rb
@@ -1,6 +1,6 @@
 cask 'bose-soundtouch' do
-  version '16.140.46-1747-f4480ce,mr3_2017-fefda4ce'
-  sha256 'ca65da84a4c35f319f8dc17c98a011e9bcfac53869ccec131c1e87e012fdd793'
+  version '17.170.80-1819-25804d2,mr4_2017_73e7b563'
+  sha256 '6a02275b5373b0ec4c9af723f8b540e0174fbdb75b6ac28312bd32f70aa9b6d2'
 
   # bose.com was verified as official when first introduced to the cask
   url "https://downloads.bose.com/ced/soundtouch/#{version.after_comma}/SoundTouch-app-installer-#{version.before_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating only the `sha256`**:

- [ ] I verified this change is legitimate [<sup>How do I do that?</sup>](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256) and **am providing confirmation below**: