### PR TITLE
Update xerox-print-driver to 4.8.0_1912

### DIFF
--- a/Casks/xerox-print-driver.rb
+++ b/Casks/xerox-print-driver.rb
@@ -10,10 +10,14 @@ cask 'xerox-print-driver' do
     version '3.52.0_1481'
     sha256 'ed958701b6adca202f0b7936cfea0fac64c2161e228f35e00f341e29df36c18f'
     url "http://download.support.xerox.com/pub/drivers/CQ8570/drivers/macosx107/pt_BR/XeroxPrintDriver.#{version}.dmg"
-  else
+  elsif MacOS.version <= :yosemite
     version '3.123.0_1865'
     sha256 'ac9c013705742538c0faa5df2194e3a7d4fb9980dd0570e41b213ff87172ee6c'
     url "http://download.support.xerox.com/pub/drivers/CQ8570/drivers/macosx1010/ar/XeroxPrintDriver_#{version}.dmg"
+  else
+    version '4.8.0_1912'
+    sha256 '4e579ea5ac2d53c8f666b71328f3108da68c9b5b91c62eded91dc9551abf4f7e'
+    url "http://download.support.xerox.com/pub/drivers/CQ8570/drivers/macosx1011/ar/XeroxPrintDriver_#{version}.dmg"
   end
 
   pkg "Xerox Print Driver #{version.major_minor_patch}.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.