### PR TITLE
correct the shasum 256 value for apogee-duet

### DIFF
--- a/Casks/apogee-duet.rb
+++ b/Casks/apogee-duet.rb
@@ -4,7 +4,7 @@ cask 'apogee-duet' do
 
   url "https://www.apogeedigital.com/drivers/Duet_#{version}.dmg"
   name 'Apogee Duet'
-  homepage 'https://www.apogeedigital.com/support/software-downloads#tab-id-8'
+  homepage 'http://www.apogeedigital.com/support/software-downloads#tab-id-8'
 
   depends_on macos: '>= :mavericks'
 

--- a/Casks/apogee-duet.rb
+++ b/Casks/apogee-duet.rb
@@ -1,10 +1,10 @@
 cask 'apogee-duet' do
   version 'June_2015'
-  sha256 '8873b43fbf8b354ba5adebaf8ce79eb0bb572c90ac86950c39b42d8f504649e3'
+  sha256 '4269af249372df7a50006f91a7dc1d73dddce9a878a247f98bd0a46d5e2619ee'
 
   url "https://www.apogeedigital.com/drivers/Duet_#{version}.dmg"
   name 'Apogee Duet'
-  homepage 'http://www.apogeedigital.com/support/software-downloads#tab-id-8'
+  homepage 'https://www.apogeedigital.com/support/software-downloads#tab-id-8'
 
   depends_on macos: '>= :mavericks'
 


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not already refused in [closed issues].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-drivers/pulls
[closed issues]: https://github.com/caskroom/homebrew-drivers/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
