### PR TITLE
Update kiibohd-configurator to 0.4.1

### DIFF
--- a/Casks/kiibohd-configurator.rb
+++ b/Casks/kiibohd-configurator.rb
@@ -1,11 +1,11 @@
 cask 'kiibohd-configurator' do
-  version '0.4.0'
-  sha256 '7050368870895dd8afef53ad16ed721cf4cb8567475c7dede9cf3953a77ce595'
+  version '0.4.1'
+  sha256 '71cd04f9b660e5ebd06c3647e153975078f8d808078e98f59caa6833631beee3'
 
   # github.com/kiibohd/configurator was verified as official when first introduced to the cask
   url "https://github.com/kiibohd/configurator/releases/download/v#{version}/kiibohd-configurator-#{version}-mac.dmg"
   appcast 'https://github.com/kiibohd/configurator/releases.atom',
-          checkpoint: '1db3516d2ce2b3935d26ecf289cccf90ebf87b27dbe2a65bd4a8227999636049'
+          checkpoint: 'e090ac22955d7e5b5952ddf8f479d8ff2caae89f002d59766822df292c020c44'
   name 'Kiibohd Configurator'
   homepage 'http://kiibohd.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.