### PR TITLE
Update bose-updater to 1.5.4.1309.6342

### DIFF
--- a/Casks/bose-updater.rb
+++ b/Casks/bose-updater.rb
@@ -2,9 +2,9 @@ cask 'bose-updater' do
   version '1.5.4.1309.6342'
   sha256 '027fa124ce45342cc925e584fc1d76cd3a8f7761e3a6db0191f82cff3e6b967a'
 
-  url "http://downloads.bose.com/ced/boseupdater/mac/BoseUpdater_#{version}.dmg"
+  url "https://downloads.bose.com/ced/boseupdater/mac/BoseUpdater_#{version}.dmg"
   name 'Bose Updater'
-  homepage 'http://btu.bose.com/'
+  homepage 'https://btu.bose.com/'
 
   app 'Bose Updater.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.