### PR TITLE
Update suunto-moveslink to 1.0.66

### DIFF
--- a/Casks/suunto-moveslink.rb
+++ b/Casks/suunto-moveslink.rb
@@ -2,7 +2,7 @@ cask 'suunto-moveslink' do
   version '1.0.66'
   sha256 '5897fe23239a4400f9f23929f2eadcc424bdc5f3f3b3da74a1c17b8ec778997c'
 
-  url "http://content.static.movescount.com/downloads/Moveslink_setup_#{version.dots_to_underscores}.dmg"
+  url "https://content.static.movescount.com/downloads/Moveslink_setup_#{version.dots_to_underscores}.dmg"
   name 'Suunto Moveslink'
   homepage 'http://www.movescount.com/connect/moveslink?os=mac'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

`homepage` downgrades to HTTP