### PR TITLE
Update prolific-pl2303 to 1.6.1_20160309

### DIFF
--- a/Casks/prolific-pl2303.rb
+++ b/Casks/prolific-pl2303.rb
@@ -2,9 +2,9 @@ cask 'prolific-pl2303' do
   version '1.6.1_20160309'
   sha256 '14868e4a3c38904760d3445c37bbb5ca2f1024498547645147abbabfcb52eb87'
 
-  url "http://prolificusa.com/files/PL2303_MacOSX_#{version}.zip"
+  url "https://prolificusa.com/files/PL2303_MacOSX_#{version}.zip"
   name 'Prolific USB-Serial Cable driver'
-  homepage 'http://prolificusa.com/'
+  homepage 'https://prolificusa.com/'
 
   pkg "PL2303_MacOSX_#{version}.pkg"
 

--- a/Casks/prolific-pl2303.rb
+++ b/Casks/prolific-pl2303.rb
@@ -8,7 +8,10 @@ cask 'prolific-pl2303' do
 
   pkg "PL2303_MacOSX_#{version}.pkg"
 
-  uninstall pkgutil: "com.prolific.prolificUsbserialCableDriverV#{version.dots_to_underscores}.ProlificUsbSerial.pkg",
+  uninstall pkgutil: [
+                       'com.Susteen.driver.PL2303',
+                       'com.prolific.driver.PL2303',
+                     ],
             kext:    'com.prolific.driver.PL2303',
             delete:  [
                        '/Library/Extensions/ProlificUsbSerial.kext',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.