### PR TITLE
Update steelseries-engine to 3.11.8

### DIFF
--- a/Casks/steelseries-engine.rb
+++ b/Casks/steelseries-engine.rb
@@ -1,6 +1,6 @@
 cask 'steelseries-engine' do
-  version '3.11.7'
-  sha256 'fd72c73c1843777fe8508e79ade5b7f34110eeca90d77ca8c80df1684fc52988'
+  version '3.11.8'
+  sha256 '5565f1f2c3af60bc6767f20e3694137ec6b4680dce03a560634365a9075cbe15'
 
   # steelseriescdn.com was verified as official when first introduced to the cask
   url "https://downloads.steelseriescdn.com/drivers/engine/SteelSeriesEngine#{version}.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.