### PR TITLE
Update synology-photo-station-uploader to 1.4.3-087

### DIFF
--- a/Casks/synology-photo-station-uploader.rb
+++ b/Casks/synology-photo-station-uploader.rb
@@ -1,6 +1,6 @@
 cask 'synology-photo-station-uploader' do
-  version '1.4.1-083'
-  sha256 '89394fa8d268c74aba56ebf1fbd293c95f340b9750d16cbe14c6e675dd74726b'
+  version '1.4.3-087'
+  sha256 'dcc1b8d3e145d85df955914b842c624d759089b5d1023fb264fdedf39b448e6e'
 
   url "https://global.download.synology.com/download/Tools/PhotoStationUploader/#{version}/Mac/PhotoStationUploader-#{version.sub(%r{.*-}, '')}-Mac-Installer.dmg"
   name 'Synology Photo Station Uploader'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.