### PR TITLE
Update nvidia-web-driver to 378.10.10.10.25.104

### DIFF
--- a/Casks/nvidia-web-driver.rb
+++ b/Casks/nvidia-web-driver.rb
@@ -1,10 +1,10 @@
 cask 'nvidia-web-driver' do
-  version '378.10.10.10.25.103'
-  sha256 '815294b7229fd69679e6d96c1a4898e23f97b1b67a779a742ee488e25672a7ed'
+  version '378.10.10.10.25.104'
+  sha256 '09eeff4db92c97668bea73b4e66a272f70e6cdf08d2b4937c0eef8d8e43c466a'
 
   url "https://images.nvidia.com/mac/pkg/#{version.major}/WebDriver-#{version}.pkg"
   appcast 'https://gfe.nvidia.com/mac-update',
-          checkpoint: '135278c3876fdc194b281293839d0e04421a0ac97545ae3bc8073eb81aacdb5a'
+          checkpoint: '71d97cd1ebb5c5c1ee9a5e2aa52a2e9ad002467d9034aa5293759c224c348327'
   name 'NVIDIA Web Driver'
   homepage 'https://www.nvidia.com/Download/index.aspx'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.