### PR TITLE
Update steelseries-engine to 3.11.10

### DIFF
--- a/Casks/steelseries-engine.rb
+++ b/Casks/steelseries-engine.rb
@@ -1,6 +1,6 @@
 cask 'steelseries-engine' do
-  version '3.11.8'
-  sha256 '5565f1f2c3af60bc6767f20e3694137ec6b4680dce03a560634365a9075cbe15'
+  version '3.11.10'
+  sha256 'ff10ccd02c2b02c144812461c8a118e6a160340ca2ef02e1f3aa83da9a490d34'
 
   # steelseriescdn.com was verified as official when first introduced to the cask
   url "https://downloads.steelseriescdn.com/drivers/engine/SteelSeriesEngine#{version}.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.