### PR TITLE
brother-p-touch-editor: remove Desktop symlink created by installer

### DIFF
--- a/Casks/brother-p-touch-editor.rb
+++ b/Casks/brother-p-touch-editor.rb
@@ -8,6 +8,10 @@ cask 'brother-p-touch-editor' do
 
   pkg "BrotherPtEdit#{version.major}.pkg"
 
+  postflight do
+    File.unlink(File.expand_path('~/Desktop/P-touch Editor.app'))
+  end
+
   uninstall pkgutil: [
                        "com.brother.P-touchEditor#{version.major}.pkg",
                        'com.brother.brotherptdriver.BrotherFonts_Common.pkg',

--- a/Casks/brother-p-touch-editor.rb
+++ b/Casks/brother-p-touch-editor.rb
@@ -9,7 +9,7 @@ cask 'brother-p-touch-editor' do
   pkg "BrotherPtEdit#{version.major}.pkg"
 
   postflight do
-    File.unlink(File.expand_path('~/Desktop/P-touch Editor.app'))
+    File.unlink("#{ENV['HOME']}/Desktop/P-touch Editor.app")
   end
 
   uninstall pkgutil: [


### PR DESCRIPTION
P-Touch Editor installer adds a symlink to desktop pointing to the application.
This is a violation of Apple HIG, so remove it.

- [+] `brew cask audit --download {{cask_file}}` is error-free.
- [+] `brew cask style --fix {{cask_file}}` reports no offenses.
- [+] The commit message includes the cask’s name and version.
