### PR TITLE
Update netgeargenie to 2.4.30(2017-12-1)

### DIFF
--- a/Casks/netgeargenie.rb
+++ b/Casks/netgeargenie.rb
@@ -1,6 +1,6 @@
 cask 'netgeargenie' do
-  version '2.4.28(2017-11-13)'
-  sha256 '6aa8129fb7c84342a6b29e014622064f292abe3a71dccc9163839fe84c719565'
+  version '2.4.30(2017-12-1)'
+  sha256 '7a4fb95e65e3db22ddf947a754ad9eac27d2cac8f9e755d00689d34fd4486087'
 
   url 'http://updates1.netgear.com/netgeargenie/mac/update/NETGEARGenieInstaller.dmg'
   name 'NETGEARGenie'


### PR DESCRIPTION
Standard installs are currently failing.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.