### PR TITLE
Add QMK Toolbox 0.0.9

### DIFF
--- a/Casks/qmk-toolbox.rb
+++ b/Casks/qmk-toolbox.rb
@@ -1,0 +1,13 @@
+cask 'qmk-toolbox' do
+  version '0.0.9'
+  sha256 'b5da22c479011e048b15ca32966c026d759c24e94d4bc182d273cccf85300f25'
+
+  # github.com/qmk/qmk_toolbox was verified as official when first introduced to the cask
+  url "https://github.com/qmk/qmk_toolbox/releases/download/#{version}/QMK.Toolbox.app.zip"
+  appcast 'https://github.com/qmk/qmk_toolbox/releases.atom',
+          checkpoint: '754d95178ed0a6b37922635f0e9b520cb054d22aee98d3c9ef11f7d69b37e1f7'
+  name 'QMK Toolbox'
+  homepage 'http://qmk.fm/'
+
+  app 'QMK Toolbox.app'
+end


### PR DESCRIPTION
QMK Toolbox allows for easy flashing of customised mechanical keyboards running the [QMK firmware](https://github.com/qmk/qmk_firmware).

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-drivers/pulls
[closed issues]: https://github.com/caskroom/homebrew-drivers/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
