### PR TITLE
Update bose-soundtouch to 17.170.80-1819-25804d2,mr4_2017_92b19449

### DIFF
--- a/Casks/bose-soundtouch.rb
+++ b/Casks/bose-soundtouch.rb
@@ -1,5 +1,5 @@
 cask 'bose-soundtouch' do
-  version '17.170.80-1819-25804d2,mr4_2017_73e7b563'
+  version '17.170.80-1819-25804d2,mr4_2017_92b19449'
   sha256 '6a02275b5373b0ec4c9af723f8b540e0174fbdb75b6ac28312bd32f70aa9b6d2'
 
   # bose.com was verified as official when first introduced to the cask


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.