### PR TITLE
Update silicon-labs-vcp-driver to 5.0.4

### DIFF
--- a/Casks/silicon-labs-vcp-driver.rb
+++ b/Casks/silicon-labs-vcp-driver.rb
@@ -1,10 +1,10 @@
 cask 'silicon-labs-vcp-driver' do
-  version '5.0.3'
-  sha256 '638cc0091686d05c4afa189b345414687a0968b2c7414e993a974bb9f2177b62'
+  version '5.0.4'
+  sha256 '83a5082421c35bd066e04d8a2d95188f010d4d4a4f7fe9d21ec4150f1238ae74'
 
   url 'https://www.silabs.com/documents/public/software/Mac_OSX_VCP_Driver.zip'
-  appcast 'https://www.silabs.com/documents/public/software/Mac_OSX_VCP_Driver_Release_Notes.txt',
-          checkpoint: '68261b79e248aa73c5fc9dd7772853ab05b79d04766c480836f68c1f0c683509'
+  appcast 'https://www.silabs.com/documents/public/release-notes/Mac_OSX_VCP_Driver_Release_Notes.txt',
+          checkpoint: 'eaf4cb245bd02f830afb51dd2a367eb752d3a4a8519ffd2ee2d2c56fdadbde68'
   name 'Silicon Labs VCP Driver'
   name 'CP210x USB to UART Bridge VCP Driver'
   homepage 'https://www.silabs.com/products/development-tools/software/usb-to-uart-bridge-vcp-drivers'

--- a/Casks/silicon-labs-vcp-driver.rb
+++ b/Casks/silicon-labs-vcp-driver.rb
@@ -13,5 +13,5 @@ cask 'silicon-labs-vcp-driver' do
 
   pkg 'Silicon Labs VCP Driver.pkg'
 
-  uninstall pkgutil: 'com.silabs.siliconLabsVcpDriver.*'
+  uninstall pkgutil: 'com.silabs.driver.CP210xVCPDriver'
 end

--- a/Casks/silicon-labs-vcp-driver.rb
+++ b/Casks/silicon-labs-vcp-driver.rb
@@ -13,5 +13,6 @@ cask 'silicon-labs-vcp-driver' do
 
   pkg 'Silicon Labs VCP Driver.pkg'
 
-  uninstall pkgutil: 'com.silabs.driver.CP210xVCPDriver'
+  uninstall pkgutil: 'com.silabs.driver.CP210xVCPDriver',
+            kext:    'com.silabs.driver.CP210xVCPDriver'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

---

Closes #326.