### PR TITLE
Evolv EScribe Suite 2_SP12

### DIFF
--- a/Casks/evolv-escribe-suite.rb
+++ b/Casks/evolv-escribe-suite.rb
@@ -1,6 +1,6 @@
 cask 'evolv-escribe-suite' do
-  version '2_SP9'
-  sha256 '5adb89b2baea36e38be5c4685ffbb182024b001ba94cf975155846b7277f2559'
+  version '2_SP12'
+  sha256 '30cab006644172e67ee3b055a0fa1566a45a639ff1148291a603c961c72f2588'
 
   url "https://downloads.evolvapor.com/SetupEScribe#{version}_INTL.pkg"
   name 'EScribe Suite'


### PR DESCRIPTION
Change log:

--- DNA 60 (firmware 1.2 SP6.1) ---
Boost (International Edition only). Boost can be configured on-device just like Temperature.
--- DNA 250 (firmware 1.2 SP6) ---
Boost (International Edition only). To aid initial heating of large Kanthal coils, it is now possible to set a Boost Punch. Boost can be configured on-device just like Temperature.
Exposed the max puff time for manufacturers.
The charging will now back off if the supply keeps disconnecting it (encountered on a Tomo power bank).
--- Production Utility ---
Fixed the bandgap test on DNA 250 1.2 SP5.1.
--- Theme Designer ---
Added alignment buttons for controls.
Added a "Maintain aspect ratio" option for picture resizing.
Copy/Paste now works with multiple controls at a time.
Expose "Hold To Change Boost" (International Edition only) for DNA 60 and DNA 250 themes.
Minor bug fixes.
--- EScribe Suite ---
Minor bug fixes.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.