### PR TITLE
Evolv EScribe Suite 2_SP12: uninstall script

### DIFF
--- a/Casks/evolv-escribe-suite.rb
+++ b/Casks/evolv-escribe-suite.rb
@@ -14,8 +14,6 @@ cask 'evolv-escribe-suite' do
                      ],
             script:  {
                        executable: '/Applications/EScribe Suite.app/Contents/MacOS/ECigStats.app/Contents/MacOS/RunProgram',
-                       args:       [
-                                     '--exit',
-                                   ],
+                       args:       ['--exit'],
                      }
 end

--- a/Casks/evolv-escribe-suite.rb
+++ b/Casks/evolv-escribe-suite.rb
@@ -11,5 +11,11 @@ cask 'evolv-escribe-suite' do
   uninstall pkgutil: [
                        'org.ecigstats.Main',
                        'com.evolvapor.EScribe.Suite',
-                     ]
+                     ],
+            script:  {
+                       executable: '/Applications/EScribe Suite.app/Contents/MacOS/ECigStats.app/Contents/MacOS/RunProgram',
+                       args:       [
+                                     '--exit',
+                                   ],
+                     }
 end


### PR DESCRIPTION
This script unloads launchctl job. This job has specific name for each installation and we can't set this name to "uninstall launchctl" field.

After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.