### PR TITLE
Update Prolific USB to Serial driver to 1.6.1_20170620

### DIFF
--- a/Casks/prolific-pl2303.rb
+++ b/Casks/prolific-pl2303.rb
@@ -5,10 +5,10 @@ cask 'prolific-pl2303' do
     url "http://www.prolific.com.tw/UserFiles/files/PL2303_MacOSX__v#{version.dots_to_underscores}.zip"
     pkg "PL2303_MacOSX_v#{version}.pkg"
   else
-    version '1.6.1_20170620,1.6.1_20160309'
+    version '1.6.1_20160309'
     sha256 '75ae5fa00c3862cfe7228a16dde06fb234a1e0b588bf7c4e29edde591a595a68'
-    url "http://www.prolific.com.tw/UserFiles/files/PL2303_MacOSX_#{version.before_comma.dots_to_underscores}.zip"
-    pkg "PL2303_MacOSX_#{version.after_comma}.pkg"
+    url "http://www.prolific.com.tw/UserFiles/files/PL2303_MacOSX_#{version.dots_to_underscores}.zip"
+    pkg "PL2303_MacOSX_#{version}.pkg"
   end
 
   name 'Prolific USB to Serial Cable driver'

--- a/Casks/prolific-pl2303.rb
+++ b/Casks/prolific-pl2303.rb
@@ -1,12 +1,18 @@
 cask 'prolific-pl2303' do
-  version '1.6.1_20160309'
-  sha256 '14868e4a3c38904760d3445c37bbb5ca2f1024498547645147abbabfcb52eb87'
+  if MacOS.version <= :mountain_lion
+    version '1.5.1_20160309'
+    sha256 'b61561766d1bc1edd520a671a6dbe06fe81016eca0db76d37eeda2f481f53798'
+    url "http://www.prolific.com.tw/UserFiles/files/PL2303_MacOSX_v#{version.dots_to_underscores}.zip"
+    pkg "PL2303_MacOSX_v#{version}.pkg"
+  else
+    version '1.6.1_20170620'
+    sha256 '75ae5fa00c3862cfe7228a16dde06fb234a1e0b588bf7c4e29edde591a595a68'
+    url "http://www.prolific.com.tw/UserFiles/files/PL2303_MacOSX_#{version.dots_to_underscores}.zip"
+    pkg 'PL2303_MacOSX_1.6.1_20160309.pkg' # For some reason the package version does not match the version in the URL
+  end
 
-  url "https://prolificusa.com/files/PL2303_MacOSX_#{version}.zip"
-  name 'Prolific USB-Serial Cable driver'
-  homepage 'https://prolificusa.com/'
-
-  pkg "PL2303_MacOSX_#{version}.pkg"
+  name 'Prolific USB to Serial Cable driver'
+  homepage 'http://www.prolific.com.tw/US/'
 
   uninstall pkgutil: [
                        'com.Susteen.driver.PL2303',
@@ -18,4 +24,8 @@ cask 'prolific-pl2303' do
                        '/var/db/receipts/*PL2303*.*',
                        '/var/db/receipts/*ProlificUSbSerial*.*',
                      ]
+
+  caveats do
+    kext
+  end
 end

--- a/Casks/prolific-pl2303.rb
+++ b/Casks/prolific-pl2303.rb
@@ -1,16 +1,14 @@
 cask 'prolific-pl2303' do
-  url_base = 'http://www.prolific.com.tw/UserFiles/files/PL2303_MacOSX'
-
   if MacOS.version <= :mountain_lion
     version '1.5.1_20160309'
     sha256 'b61561766d1bc1edd520a671a6dbe06fe81016eca0db76d37eeda2f481f53798'
-    url "#{url_base}_v#{version.dots_to_underscores}.zip"
+    url "http://www.prolific.com.tw/UserFiles/files/PL2303_MacOSX__v#{version.dots_to_underscores}.zip"
     pkg "PL2303_MacOSX_v#{version}.pkg"
   else
-    version '1.6.1_20170620'
+    version '1.6.1_20170620,1.6.1_20160309'
     sha256 '75ae5fa00c3862cfe7228a16dde06fb234a1e0b588bf7c4e29edde591a595a68'
-    url "#{url_base}_#{version.dots_to_underscores}.zip"
-    pkg 'PL2303_MacOSX_1.6.1_20160309.pkg' # For some reason the package version does not match the version in the URL
+    url "http://www.prolific.com.tw/UserFiles/files/PL2303_MacOSX_#{version.before_comma.dots_to_underscores}.zip"
+    pkg "PL2303_MacOSX_#{version.after_comma}.pkg"
   end
 
   name 'Prolific USB to Serial Cable driver'

--- a/Casks/prolific-pl2303.rb
+++ b/Casks/prolific-pl2303.rb
@@ -24,8 +24,4 @@ cask 'prolific-pl2303' do
                        '/var/db/receipts/*PL2303*.*',
                        '/var/db/receipts/*ProlificUSbSerial*.*',
                      ]
-
-  caveats do
-    kext
-  end
 end

--- a/Casks/prolific-pl2303.rb
+++ b/Casks/prolific-pl2303.rb
@@ -1,13 +1,15 @@
 cask 'prolific-pl2303' do
+  url_base = 'http://www.prolific.com.tw/UserFiles/files/PL2303_MacOSX'
+
   if MacOS.version <= :mountain_lion
     version '1.5.1_20160309'
     sha256 'b61561766d1bc1edd520a671a6dbe06fe81016eca0db76d37eeda2f481f53798'
-    url "http://www.prolific.com.tw/UserFiles/files/PL2303_MacOSX_v#{version.dots_to_underscores}.zip"
+    url "#{url_base}_v#{version.dots_to_underscores}.zip"
     pkg "PL2303_MacOSX_v#{version}.pkg"
   else
     version '1.6.1_20170620'
     sha256 '75ae5fa00c3862cfe7228a16dde06fb234a1e0b588bf7c4e29edde591a595a68'
-    url "http://www.prolific.com.tw/UserFiles/files/PL2303_MacOSX_#{version.dots_to_underscores}.zip"
+    url "#{url_base}_#{version.dots_to_underscores}.zip"
     pkg 'PL2303_MacOSX_1.6.1_20160309.pkg' # For some reason the package version does not match the version in the URL
   end
 

--- a/Casks/prolific-pl2303.rb
+++ b/Casks/prolific-pl2303.rb
@@ -5,10 +5,10 @@ cask 'prolific-pl2303' do
     url "http://www.prolific.com.tw/UserFiles/files/PL2303_MacOSX__v#{version.dots_to_underscores}.zip"
     pkg "PL2303_MacOSX_v#{version}.pkg"
   else
-    version '1.6.1_20160309'
+    version '1.6.1_20170620,1.6.1_20160309'
     sha256 '75ae5fa00c3862cfe7228a16dde06fb234a1e0b588bf7c4e29edde591a595a68'
-    url "http://www.prolific.com.tw/UserFiles/files/PL2303_MacOSX_#{version.dots_to_underscores}.zip"
-    pkg "PL2303_MacOSX_#{version}.pkg"
+    url "http://www.prolific.com.tw/UserFiles/files/PL2303_MacOSX_#{version.before_comma.dots_to_underscores}.zip"
+    pkg "PL2303_MacOSX_#{version.after_comma}.pkg"
   end
 
   name 'Prolific USB to Serial Cable driver'


### PR DESCRIPTION
Changes:
- Update Prolific USB to Serial driver to version 1.6.1_20170620
- Use official Prolific website as download source (prolificusa.com is a distributor and child company of Tectona Electronics Inc)
- Respect version limitations of MacOS Mountain Lion and below
- Add caveats stanza for kext installation

Notes:
- Version string in download URL and package file do not match in this release. 


<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not already refused in [closed issues].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-drivers/pulls
[closed issues]: https://github.com/caskroom/homebrew-drivers/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
