### PR TITLE
Update steelseries-engine to 3.11.13

### DIFF
--- a/Casks/steelseries-engine.rb
+++ b/Casks/steelseries-engine.rb
@@ -1,6 +1,6 @@
 cask 'steelseries-engine' do
-  version '3.11.11'
-  sha256 'a77c3391cd2a6d2ebf275cb826934b5a7402d96ff2f3baa3dde32225215a7dac'
+  version '3.11.13'
+  sha256 '3bb4b0be206d27b5130654430e88f0faa9eed88afc99279f710e5db2b98a1839'
 
   # steelseriescdn.com was verified as official when first introduced to the cask
   url "https://downloads.steelseriescdn.com/drivers/engine/SteelSeriesEngine#{version}.pkg"
@@ -10,11 +10,13 @@ cask 'steelseries-engine' do
   pkg "SteelSeriesEngine#{version}.pkg"
 
   uninstall pkgutil:   [
+                         'com.steelseries.installer.driver',
                          'com.steelseries.SSENext',
                          'com.steelseries.ssenext.driver',
                          'com.steelseries.ssenext.driver.signed',
                          'com.steelseries.ssenext.uninstaller',
                        ],
+            kext:      'com.steelseries.ssenext.driver',
             launchctl: 'com.steelseries.SSENext',
             quit:      "com.steelseries.SteelSeries-Engine-#{version.major}"
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.