### PR TITLE
add auto_updates stanza to synology casks

### DIFF
--- a/Casks/synology-cloud-station-backup.rb
+++ b/Casks/synology-cloud-station-backup.rb
@@ -6,6 +6,8 @@ cask 'synology-cloud-station-backup' do
   name 'Synology Cloud Station Backup'
   homepage 'https://www.synology.com/'
 
+  auto_updates true
+
   pkg 'Install Cloud Station Backup.pkg'
 
   uninstall pkgutil:   'com.synology.CloudStationBackup',

--- a/Casks/synology-drive.rb
+++ b/Casks/synology-drive.rb
@@ -6,6 +6,8 @@ cask 'synology-drive' do
   name 'Synology Drive'
   homepage 'https://www.synology.com/'
 
+  auto_updates true
+
   pkg 'Install Synology Drive.pkg'
 
   uninstall pkgutil:   'com.synology.CloudStation',


### PR DESCRIPTION
The apps synology-cloud-station-backup and synology-drive include auto-updaters.
This pull request sets the `auto_updates` property to `true`.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.
