### PR TITLE
Update segger-jlink to 6.30h

### DIFF
--- a/Casks/segger-jlink.rb
+++ b/Casks/segger-jlink.rb
@@ -1,6 +1,6 @@
 cask 'segger-jlink' do
-  version '6.30g'
-  sha256 '6179d39e437260d0e55c4cf679871962a380df2fd54b61082ac58e7c539ac663'
+  version '6.30h'
+  sha256 '40418b384e7fea2338985d5cad2295876cfcdf60ce90bae0029da6cf66ec73b9'
 
   url "https://www.segger.com/downloads/flasher/JLink_MacOSX_V#{version.no_dots}.pkg",
       using: :post,


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.