### PR TITLE
Update segger-jlink to 6.30j

### DIFF
--- a/Casks/segger-jlink.rb
+++ b/Casks/segger-jlink.rb
@@ -1,6 +1,6 @@
 cask 'segger-jlink' do
-  version '6.30i'
-  sha256 'ccfbaf599bb4dd3c71bc91f1d858b86c7c7c91256c460bee02f52b42f27f68ce'
+  version '6.30j'
+  sha256 '6f6fac3811bff5785a41be8399b142bde565235e5f6ac6c4257475ebcb3f2aef'
 
   url "https://www.segger.com/downloads/flasher/JLink_MacOSX_V#{version.no_dots}.pkg",
       using: :post,


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.