### PR TITLE
Update asix-ax88179 to 2.10.0

### DIFF
--- a/Casks/asix-ax88179.rb
+++ b/Casks/asix-ax88179.rb
@@ -21,4 +21,8 @@ cask 'asix-ax88179' do
                           },
             kext:         'com.asix.driver.ax88179-178a',
             pkgutil:      'com.asix.pkg.ax88179-178a*'
+
+  caveats do
+    reboot
+  end
 end

--- a/Casks/asix-ax88179.rb
+++ b/Casks/asix-ax88179.rb
@@ -2,30 +2,13 @@ cask 'asix-ax88179' do
   version '2.10.0'
   sha256 '2b03b808c919112cb50b85e63b811531308c0d5d395a86f3f6617c783210f852'
 
-  module Utils
-    def self.basename(version)
-      "AX88179_178A_Macintosh_Driver_Installer_v#{version}"
-    end
-  end
-
   url "http://www.asix.com.tw/FrootAttach/driver/AX88179_178A_Macintosh_Driver_Installer_v#{version}.zip"
   name 'AX88179'
   homepage 'http://www.asix.com.tw/download.php?sub=driverdetail&PItemID=131'
 
-  pkg "AX88179_178A_v#{version}.pkg"
+  container nested: "AX88179_178A_Macintosh_Driver_Installer_v#{version}/AX88179_178A.dmg"
 
-  # HACK: DMG needs to be extracted manually because it is using an MBR partition table.
-  preflight do
-    begin
-      dmg_mount = `/usr/bin/hdiutil mount -readonly -noidme -nobrowse -mountrandom /tmp '#{staged_path.join(Utils.basename(version), 'AX88179_178A.dmg')}' | /usr/bin/cut -f3 -- - | /usr/bin/grep -- '.' -`.chop
-      FileUtils.cp(Dir.glob("#{dmg_mount}/AX*"), staged_path)
-    ensure
-      system_command '/usr/bin/hdiutil',
-                     args:         ['eject', dmg_mount],
-                     print_stdout: false,
-                     print_stderr: false
-    end
-  end
+  pkg "AX88179_178A_v#{version}.pkg"
 
   postflight do
     system_command '/sbin/kextload',

--- a/Casks/asix-ax88179.rb
+++ b/Casks/asix-ax88179.rb
@@ -1,6 +1,6 @@
 cask 'asix-ax88179' do
-  version '2.9.0_20171130'
-  sha256 'f625948935cdb80f3bdc6fbe56a99a77525bd62178104b4c8508d27cb5b8b8ef'
+  version '2.10.0'
+  sha256 '2b03b808c919112cb50b85e63b811531308c0d5d395a86f3f6617c783210f852'
 
   module Utils
     def self.basename(version)
@@ -8,11 +8,11 @@ cask 'asix-ax88179' do
     end
   end
 
-  url "http://www.asix.com.tw/FrootAttach/driver/#{Utils.basename(version)}.zip"
+  url "http://www.asix.com.tw/FrootAttach/driver/AX88179_178A_Macintosh_Driver_Installer_v#{version}.zip"
   name 'AX88179'
   homepage 'http://www.asix.com.tw/download.php?sub=driverdetail&PItemID=131'
 
-  pkg "AX88179_178A_v#{version.sub(%r{_.*}, '')}.pkg"
+  pkg "AX88179_178A_v#{version}.pkg"
 
   # HACK: DMG needs to be extracted manually because it is using an MBR partition table.
   preflight do


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.