### PR TITLE
Update lmsclients-squeezeplay to 7.8.0r1072

### DIFF
--- a/Casks/lmsclients-squeezeplay.rb
+++ b/Casks/lmsclients-squeezeplay.rb
@@ -1,11 +1,11 @@
 cask 'lmsclients-squeezeplay' do
-  version '7.8.0r1034'
-  sha256 'f79c47342f45058113d559baac83f3b01d770c8c8dda8c799428b62f70331a10'
+  version '7.8.0r1072'
+  sha256 'daecd41fad9d6edbbab9bde6fbc5ddef0fbb80909b99a13def8b1f233c003ff6'
 
   # downloads.sourceforge.net/lmsclients was verified as official when first introduced to the cask
   url "https://downloads.sourceforge.net/lmsclients/SqueezePlay-x86_64-#{version}.dmg"
   appcast 'https://sourceforge.net/projects/lmsclients/rss?path=/squeezeplay/osx',
-          checkpoint: '27606deaec7cda01be1809ec4e5bd13c997bcd177b1b98467ac400a71bdb978b'
+          checkpoint: 'fa360234322c4439d2a6420788694b33a910ba3f533a46256ca0776d0a282f00'
   name 'Logitech LMS SqueezePlay Client'
   homepage 'http://forums.slimdevices.com/showthread.php?96328-ANNOUNCE-SqueezePlay-for-Mac-OSX'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.