### PR TITLE
Update canon-imagerunner-printer-driver-ufrii to 10.15.00

### DIFF
--- a/Casks/canon-imagerunner-printer-driver-ufrii.rb
+++ b/Casks/canon-imagerunner-printer-driver-ufrii.rb
@@ -1,10 +1,10 @@
 cask 'canon-imagerunner-printer-driver-ufrii' do
-  version '10.14.00'
-  sha256 '8fac2ab483e96a772b4bcc20a569a99142d5e65298f357ccbaae3f5a2ccb6a1a'
+  version '10.15.00'
+  sha256 '819181ebc0becfdb2cab2fb4809c957ae88ce1991a29b9ce1a45572e68420b17'
 
-  url "https://downloads.canon.com/bisg2017/drivers/mac/UFRII_v#{version}_Mac.zip"
+  url "https://downloads.canon.com/bisg2018/drivers/mac/UFRII_v#{version}_Mac.zip"
   appcast 'https://www.usa.canon.com/internet/PA_NWSupport/driversDownloads?model=15802&os=MACOS_V10_12&type=DS&lang=English',
-          checkpoint: '6a0feb046e6d63f6e703a56d762acbad70dc6c42184590975c88b57413c8522e'
+          checkpoint: '8e5f135aa054d414351565b1ef967b215f94ed40b69d98a43eeeeb6e9d03e8a4'
   name 'Canon imageRUNNER UFRII Printer Driver'
   homepage 'https://www.usa.canon.com/internet/portal/us/home/support/details/copiers-mfps-fax-machines/support-multifunction/imagerunner-2018'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.