### PR TITLE
Update nvidia-web-driver to 387.10.10.10.30.106

### DIFF
--- a/Casks/nvidia-web-driver.rb
+++ b/Casks/nvidia-web-driver.rb
@@ -1,10 +1,10 @@
 cask 'nvidia-web-driver' do
-  version '387.10.10.10.30.103'
-  sha256 'b629d14094afc9565c6331116d920301064336bbd16d20ba73514940cf9631dd'
+  version '387.10.10.10.30.106'
+  sha256 'c7685e947c6cd0237e62d10ef4070c1591e88fc6189785638d6d08b1ff9badfd'
 
   url "https://images.nvidia.com/mac/pkg/#{version.major}/WebDriver-#{version}.pkg"
   appcast 'https://gfe.nvidia.com/mac-update',
-          checkpoint: 'eb2dd0c64a3a98889ae521faa2cbfd7d72c479367d234018d8ca0794968ba832'
+          checkpoint: 'a9e64f770ad62ad97c54e47b9990ab247efa08bc53c476c4a05501301e919074'
   name 'NVIDIA Web Driver'
   homepage 'https://www.nvidia.com/Download/index.aspx'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.