### PR TITLE
Update ubiquiti-unifi-controller to 5.7.23

### DIFF
--- a/Casks/ubiquiti-unifi-controller.rb
+++ b/Casks/ubiquiti-unifi-controller.rb
@@ -1,6 +1,6 @@
 cask 'ubiquiti-unifi-controller' do
-  version '5.6.30'
-  sha256 '667908f1e60fe656e600751ae70331e9e860ff9454a44094280979cbbbddc5bb'
+  version '5.7.20'
+  sha256 'f1a8b4ce9ea1fb9661aa2e9ad3a4476ceb0f58d072d5f3ee89a61d9805eb8e03'
 
   url "https://dl.ubnt.com/unifi/#{version}/UniFi.pkg"
   name 'UniFi Controller'
@@ -14,5 +14,10 @@ cask 'ubiquiti-unifi-controller' do
     set_ownership '~/Library/Application Support/UniFi'
   end
 
-  uninstall pkgutil: 'com.ubnt.UniFi'
+  uninstall pkgutil: 'com.ubnt.UniFi',
+
+            delete:  [
+                       '/Applications/UniFi.app',
+                       '/Applications/UniFi-Discover.app',
+                     ]
 end

--- a/Casks/ubiquiti-unifi-controller.rb
+++ b/Casks/ubiquiti-unifi-controller.rb
@@ -1,6 +1,6 @@
 cask 'ubiquiti-unifi-controller' do
-  version '5.7.20'
-  sha256 'f1a8b4ce9ea1fb9661aa2e9ad3a4476ceb0f58d072d5f3ee89a61d9805eb8e03'
+  version '5.7.23'
+  sha256 'faa5f2f4d10706e11f57e1236c1627e1f97343b9f49777e9b4d559fabe0f49c7'
 
   url "https://dl.ubnt.com/unifi/#{version}/UniFi.pkg"
   name 'UniFi Controller'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.