### PR TITLE
Update bragi-updater to 1.1.2

### DIFF
--- a/Casks/bragi-updater.rb
+++ b/Casks/bragi-updater.rb
@@ -1,10 +1,10 @@
 cask 'bragi-updater' do
   version '1.1.2'
-  sha256 '7430e20897da336aba59849ce23e4815dfe24b05772106c47254e2269e7022a0'
+  sha256 '4d3834015c135f82f20ae80fd21c31e8ee645a6b57d01b0cd985e41c9c42dee6'
 
   url "http://update.bragi.com/bin/Bragi%20Updater-#{version}.dmg"
   appcast 'http://update.bragi.com/',
-          checkpoint: '400f9e0c852450239d75eaf45445486a1e69cc4444cc8057d59167d5a5115648'
+          checkpoint: '0c70c4f6a5ff8af67f9254cfcabcaf83eeae4ef21f14d6cb10c14140545fb867'
   name 'Bragi Updater'
   homepage 'http://update.bragi.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.