### PR TITLE
Add Behringer DeepMind 12 app

### DIFF
--- a/Casks/behringer-deepmind.rb
+++ b/Casks/behringer-deepmind.rb
@@ -1,0 +1,11 @@
+cask 'behringer-deepmind' do
+  version :latest
+  sha256 :no_check
+
+  # s3.amazonaws.com/cdn.mymcloud.xyz/behringer was verified as official when first introduced to the cask
+  url 'https://s3.amazonaws.com/cdn.mymcloud.xyz/behringer/application/DeepMindAppMacOS.app.zip'
+  name 'Behringer Deepmind 12'
+  homepage 'https://www.musictri.be/brand/behringer/home'
+
+  app 'DeepMind12.app'
+end

--- a/Casks/behringer-deepmind12.rb
+++ b/Casks/behringer-deepmind12.rb
@@ -1,4 +1,5 @@
-cask 'behringer-deepmind' do
+cask 'behringer-deepmind12' do
+  # note: "12" is not a version number, but an intrinsic part of the product name
   version :latest
   sha256 :no_check
 


### PR DESCRIPTION
Note the app is named DeepMind 12 (this is not the version).
App works for Behringer DeepMind 6, DeepMind 12, DeepMind 12D synths
Confirm url is linked from
https://www.musictri.be/Categories/Behringer/Keyboards/Synthesizers-and-Samplers/DEEPMIND-12/p/P0AC5/downloads

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version. (Download has no versioned form).

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-drivers/pulls
[closed issues]: https://github.com/caskroom/homebrew-drivers/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
