### PR TITLE
Update plantronics-hub to latest and add zap

### DIFF
--- a/Casks/plantronics-hub.rb
+++ b/Casks/plantronics-hub.rb
@@ -16,9 +16,7 @@ cask 'plantronics-hub' do
                          'com.plantronics.plantronicsSoftware.preflight.pkg',
                          'Plantronics-Inc..Plantronics-Hub',
                        ],
-            launchctl: [
-                         'com.PlantronicsUpdateService',
-                       ]
+            launchctl: 'com.PlantronicsUpdateService'
 
   zap trash: [
                '~/Library/Application Support/Plantronics',

--- a/Casks/plantronics-hub.rb
+++ b/Casks/plantronics-hub.rb
@@ -2,7 +2,7 @@ cask 'plantronics-hub' do
   version :latest
   sha256 :no_check
 
-  url 'https://www.plantronics.com/media/downloads/PlantronicsHubInstaller.dmg'
+  url 'https://www.plantronics.com/content/dam/plantronics/software/PlantronicsHubInstaller.dmg'
   name 'Plantronics Hub'
   homepage 'https://www.plantronics.com/au/product/plantronics-hub-desktop'
 
@@ -11,8 +11,19 @@ cask 'plantronics-hub' do
 
   pkg 'Plantronics Software.pkg'
 
-  uninstall pkgutil: [
-                       'com.plantronics.plantronicsSoftware.PlantronicsHub.pkg',
-                       'com.plantronics.plantronicsSoftware.preflight.pkg',
-                     ]
+  uninstall pkgutil:   [
+                         'com.plantronics.plantronicsSoftware.PlantronicsHub.pkg',
+                         'com.plantronics.plantronicsSoftware.preflight.pkg',
+                         'Plantronics-Inc..Plantronics-Hub',
+                       ],
+            launchctl: [
+                         'com.PlantronicsUpdateService',
+                       ]
+
+  zap trash: [
+               '~/Library/Application Support/Plantronics',
+               '~/Library/Preferences/Plantronics-Inc..Plantronics-Hub.plist',
+               '~/Library/Preferences/Plantronics.Plantronics-Hub-Helper.plist',
+               '~/Library/Saved Application State/Plantronics-Inc..Plantronics-Hub.savedState',
+             ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Ed1t:

Newest version is hosten via a different url path.