### PR TITLE
Update blackvue-viewer to 1.20,74331

### DIFF
--- a/Casks/blackvue-viewer.rb
+++ b/Casks/blackvue-viewer.rb
@@ -1,10 +1,12 @@
 cask 'blackvue-viewer' do
-  version '1.13,74331'
-  sha256 '0eee70b2492d029fc959cb560d44be110f11355b9644f9e1930c2dba0d00326d'
+  version '1.20,74331'
+  sha256 '82784dcb6c006998a06acb94bd4eab8030958a70f3fbff290793c7722d65a58b'
 
   url "https://www.blackvue.com/download/blackvue-mac-viewer-cloud/?wpdmdl=#{version.after_comma}"
   name 'BlackVue Viewer'
   homepage 'https://www.blackvue.com/'
+
+  depends_on macos: '>= :yosemite'
 
   app 'BlackVue Viewer.app'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.